### PR TITLE
treewide: stm32wl-hal -> stm32wlxx-hal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "defmt-rtt",
  "nucleo-wl55jc-bsp",
  "panic-probe",
- "stm32wl-hal",
+ "stm32wlxx-hal",
 ]
 
 [[package]]
@@ -257,7 +257,7 @@ dependencies = [
 name = "lora-e5-bsp"
 version = "0.1.0-alpha.0"
 dependencies = [
- "stm32wl-hal",
+ "stm32wlxx-hal",
 ]
 
 [[package]]
@@ -279,7 +279,7 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 name = "nucleo-wl55jc-bsp"
 version = "0.1.0-alpha.0"
 dependencies = [
- "stm32wl-hal",
+ "stm32wlxx-hal",
 ]
 
 [[package]]
@@ -462,7 +462,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "stm32wl-hal"
+name = "stm32wlxx-hal"
 version = "0.1.0-alpha.0"
 dependencies = [
  "cfg-if",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# stm32wl-hal
+# stm32wlxx-hal
 
-[![CI](https://github.com/newAM/stm32wl-hal/workflows/CI/badge.svg)](https://github.com/newAM/stm32wl-hal/actions?query=branch%3Amain)
-[![docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://newam.github.io/stm32wl-hal/stm32wl_hal/index.html)
+[![CI](https://github.com/newAM/stm32wlxx-hal/workflows/CI/badge.svg)](https://github.com/newAM/stm32wlxx-hal/actions?query=branch%3Amain)
+[![docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://newam.github.io/stm32wlxx-hal/stm32wlxx_hal/index.html)
 
 Embedded rust HAL (hardware abstraction layer) for the STM32WL series.
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ defmt = "0.2"
 defmt-rtt = "0.2"
 cortex-m-rt = "0.6"
 panic-probe = { version = "0.2", features = ["print-defmt" ] }
-stm32wl-hal = { path = "../hal", features = ["stm32wl5x_cm4", "rt", "defmt"] }
+stm32wlxx-hal = { path = "../hal", features = ["stm32wl5x_cm4", "rt", "defmt"] }
 nucleo-wl55jc-bsp = { path = "../nucleo-wl55jc-bsp" }
 
 [features]

--- a/examples/examples/clock.rs
+++ b/examples/examples/clock.rs
@@ -5,7 +5,7 @@
 
 use defmt_rtt as _; // global logger
 use panic_probe as _; // panic handler
-use stm32wl_hal::{self as hal, pac, rcc};
+use stm32wlxx_hal::{self as hal, pac, rcc};
 
 #[hal::cortex_m_rt::entry]
 fn main() -> ! {

--- a/examples/examples/gpio-blink.rs
+++ b/examples/examples/gpio-blink.rs
@@ -5,7 +5,7 @@
 
 use defmt_rtt as _; // global logger
 use panic_probe as _; // panic handler
-use stm32wl_hal::{
+use stm32wlxx_hal::{
     self as hal,
     cortex_m::{self, delay::Delay},
     gpio::{pins, Output, PinState, PortB},

--- a/examples/examples/gpio-button-irq.rs
+++ b/examples/examples/gpio-button-irq.rs
@@ -5,7 +5,7 @@
 
 use defmt_rtt as _; // global logger
 use panic_probe as _; // panic handler
-use stm32wl_hal::{
+use stm32wlxx_hal::{
     self as hal, cortex_m,
     gpio::{pins, Exti, ExtiTrg, Input, PortC, Pull},
     pac::{self, interrupt},

--- a/examples/examples/gpio-button.rs
+++ b/examples/examples/gpio-button.rs
@@ -5,7 +5,7 @@
 
 use defmt_rtt as _; // global logger
 use panic_probe as _; // panic handler
-use stm32wl_hal::{
+use stm32wlxx_hal::{
     self as hal, cortex_m,
     gpio::{pins, Input, PinState, PortC, Pull},
     pac,

--- a/examples/examples/info.rs
+++ b/examples/examples/info.rs
@@ -5,7 +5,7 @@
 
 use defmt_rtt as _; // global logger
 use panic_probe as _; // panic handler
-use stm32wl_hal::{self as hal, info};
+use stm32wlxx_hal::{self as hal, info};
 
 #[hal::cortex_m_rt::entry]
 fn main() -> ! {

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stm32wl-hal"
+name = "stm32wlxx-hal"
 description = "Hardware abstraction layer for the STM32WL series microcontrollers."
 readme = "README.md"
 
@@ -9,7 +9,7 @@ edition = "2021"
 license = "MIT"
 keywords = ["arm", "cortex-m", "stm32", "hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-repository = "https://github.com/newAM/stm32wl-hal"
+repository = "https://github.com/newAM/stm32wlxx-hal"
 
 [features]
 stm32wl5x_cm0p = ["stm32wl/stm32wl5x_cm0p"]

--- a/hal/README.md
+++ b/hal/README.md
@@ -6,8 +6,8 @@ This crate is not yet published to crates.io, see issue [#149] for details.
 Until then please pin the version you use.
 
 ```toml
-[dependencies.stm32wl-hal]
-git = "https://github.com/newAM/stm32wl-hal.git"
+[dependencies.stm32wlxx-hal]
+git = "https://github.com/newAM/stm32wlxx-hal.git"
 rev = "" # put a specific git commit hash here
 features = [
     # use exactly one of the following depending on your target hardware
@@ -21,7 +21,7 @@ features = [
 ]
 
 # include cortex-m-rt directly in your crate if you need interrupts
-# use the interrupt macro from the hal with `use stm32wl_hal::pac::interrupt;`
+# use the interrupt macro from the hal with `use stm32wlxx_hal::pac::interrupt;`
 # DO NOT use the interrupt macro from cortex-m-rt, it will fail to compile
 [dependencies]
 cortex-m-rt = "0.6"
@@ -31,7 +31,7 @@ cortex-m-rt = "0.6"
 or `stm32wl` (the PAC) directly, these are re-exported by the hal.
 
 ```rust
-use stm32wl_hal as hal;
+use stm32wlxx_hal as hal;
 
 use hal::cortex_m;
 use hal::cortex_m_rt; // requires "rt" feature
@@ -64,7 +64,7 @@ simple enough. That being said if you find somthing missing it is likely
 because this crate is incomplete, and not an intentional design decision.
 
 ```rust
-use stm32wl_hal as hal;
+use stm32wlxx_hal as hal;
 use hal::pac;
 
 use hal::{aes::Aes, pka::Pka};
@@ -97,5 +97,5 @@ this is not consistent (see [#78])
 
 [stm32-rs]: https://github.com/stm32-rs/stm32-rs
 [svd2rust]: https://github.com/rust-embedded/svd2rust
-[#78]: https://github.com/newAM/stm32wl-hal/issues/78
-[#149]: https://github.com/newAM/stm32wl-hal/issues/149
+[#78]: https://github.com/newAM/stm32wlxx-hal/issues/78
+[#149]: https://github.com/newAM/stm32wlxx-hal/issues/149

--- a/hal/src/adc.rs
+++ b/hal/src/adc.rs
@@ -65,7 +65,7 @@ pub const T_ADCVREG_SETUP: Duration = Duration::from_micros(20);
 /// # Example
 ///
 /// ```
-/// use stm32wl_hal::adc::{T_ADCVREG_SETUP, T_ADCVREG_SETUP_MICROS};
+/// use stm32wlxx_hal::adc::{T_ADCVREG_SETUP, T_ADCVREG_SETUP_MICROS};
 ///
 /// assert_eq!(
 ///     u128::from(T_ADCVREG_SETUP_MICROS),
@@ -199,7 +199,7 @@ impl Ts {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::adc::Ts;
+    /// use stm32wlxx_hal::adc::Ts;
     ///
     /// assert_eq!(Ts::MAX, Ts::Cyc160);
     /// ```
@@ -210,7 +210,7 @@ impl Ts {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::adc::Ts;
+    /// use stm32wlxx_hal::adc::Ts;
     ///
     /// assert_eq!(Ts::MIN, Ts::Cyc1);
     /// ```
@@ -221,7 +221,7 @@ impl Ts {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::adc::Ts;
+    /// use stm32wlxx_hal::adc::Ts;
     ///
     /// assert!(f32::from(Ts::Cyc1.cycles()) - 1.5 < 0.001);
     /// assert!(f32::from(Ts::Cyc3.cycles()) - 3.5 < 0.001);
@@ -257,7 +257,7 @@ impl Ts {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::adc::Ts;
+    /// use stm32wlxx_hal::adc::Ts;
     ///
     /// const FREQ: u32 = 16_000_000;
     ///
@@ -363,7 +363,7 @@ impl Ch {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::adc::Ch;
+    /// use stm32wlxx_hal::adc::Ch;
     ///
     /// assert_eq!(Ch::In0.mask(), 0x001);
     /// assert_eq!(Ch::In8.mask(), 0x100);
@@ -394,7 +394,7 @@ impl Adc {
     /// Initialize the ADC with HSI16.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -411,7 +411,7 @@ impl Adc {
     /// Initialize the ADC with PCLK/4.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -441,7 +441,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -469,7 +469,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -499,7 +499,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -534,7 +534,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -563,7 +563,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -633,7 +633,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -705,7 +705,7 @@ impl Adc {
     ///
     /// ```no_run
     /// # #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
-    /// unsafe { stm32wl_hal::adc::Adc::unmask_irq() };
+    /// unsafe { stm32wlxx_hal::adc::Adc::unmask_irq() };
     /// ```
     #[cfg(feature = "rt")]
     #[inline]
@@ -719,7 +719,7 @@ impl Adc {
     ///
     /// ```no_run
     /// # #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
-    /// unsafe { stm32wl_hal::adc::Adc::mask_irq() }
+    /// unsafe { stm32wlxx_hal::adc::Adc::mask_irq() }
     /// ```
     #[cfg(feature = "rt")]
     #[inline]
@@ -746,7 +746,7 @@ impl Adc {
     /// 160.5 clock cycles.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     self as hal,
     ///     adc::{self, Adc, Ts},
     ///     gpio::pins::{B13, B14},
@@ -782,8 +782,8 @@ impl Adc {
     /// This method is equivalent to this:
     ///
     /// ```no_run
-    /// # let mut adc = unsafe { stm32wl_hal::adc::Adc::steal() };
-    /// use stm32wl_hal::adc::Ts;
+    /// # let mut adc = unsafe { stm32wlxx_hal::adc::Adc::steal() };
+    /// use stm32wlxx_hal::adc::Ts;
     ///
     /// adc.set_sample_times(0, Ts::Cyc160, Ts::Cyc160);
     /// ```
@@ -791,7 +791,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -812,7 +812,7 @@ impl Adc {
     /// Clear all interrupts.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -834,7 +834,7 @@ impl Adc {
     /// Check if the ADC is ready.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -857,7 +857,7 @@ impl Adc {
     /// Enable all IRQs
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -893,7 +893,7 @@ impl Adc {
     /// Select the ADC V<sub>BAT</sub> channel.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -968,7 +968,7 @@ impl Adc {
     /// Read the ADC V<sub>BAT</sub> channel.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     ///     util::new_delay,
@@ -1025,7 +1025,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac, rcc,
     ///     util::new_delay,
@@ -1089,7 +1089,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac, rcc,
     ///     util::new_delay,
@@ -1161,7 +1161,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac, rcc,
     ///     util::new_delay,
@@ -1208,7 +1208,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     dac::{Dac, ModeChip},
     ///     pac, rcc,
@@ -1253,7 +1253,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     gpio::{pins::B4, Analog, PortB},
     ///     pac, rcc,
@@ -1323,7 +1323,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     self as hal,
     ///     adc::{self, Adc},
     ///     dac::{Dac, ModeChip},
@@ -1366,7 +1366,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -1399,7 +1399,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -1437,7 +1437,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -1465,7 +1465,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -1497,7 +1497,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -1535,7 +1535,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac,
     /// };
@@ -1581,7 +1581,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac, rcc,
     ///     util::new_delay,
@@ -1625,7 +1625,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac, rcc,
     ///     util::new_delay,
@@ -1692,7 +1692,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac, rcc,
     ///     util::new_delay,
@@ -1750,7 +1750,7 @@ impl Adc {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     adc::{self, Adc},
     ///     pac, rcc,
     ///     util::new_delay,

--- a/hal/src/aes.rs
+++ b/hal/src/aes.rs
@@ -88,7 +88,7 @@ impl AesWrapClk {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     aes::{Aes, AesWrapClk},
     ///     pac,
     /// };
@@ -104,7 +104,7 @@ impl AesWrapClk {
     ///
     /// let mut text: [u32; 4] = [0xf34481ec, 0x3cc627ba, 0xcd5dc3fb, 0x08f273e6];
     /// aeswrap.with_clk(&mut dp.RCC, |aes| aes.encrypt_ecb_inplace(&KEY, &mut text))?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     ///
     /// [`enable_clock`]: Aes::enable_clock
@@ -155,7 +155,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -176,7 +176,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -215,7 +215,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -259,7 +259,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     ///
@@ -293,7 +293,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// // AES cannot be used via registers now
@@ -330,7 +330,7 @@ impl Aes {
     ///
     /// ```no_run
     /// # #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
-    /// unsafe { stm32wl_hal::aes::Aes::unmask_irq() };
+    /// unsafe { stm32wlxx_hal::aes::Aes::unmask_irq() };
     /// ```
     #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
     #[inline]
@@ -684,7 +684,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -694,7 +694,7 @@ impl Aes {
     /// let plaintext: [u32; 4] = [0xf34481ec, 0x3cc627ba, 0xcd5dc3fb, 0x08f273e6];
     /// let mut ciphertext: [u32; 4] = [0; 4];
     /// aes.encrypt_ecb(&KEY, &plaintext, &mut ciphertext)?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     pub fn encrypt_ecb(
         &mut self,
@@ -743,7 +743,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -752,7 +752,7 @@ impl Aes {
     ///
     /// let mut text: [u32; 4] = [0xf34481ec, 0x3cc627ba, 0xcd5dc3fb, 0x08f273e6];
     /// aes.encrypt_ecb_inplace(&KEY, &mut text)?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     pub fn encrypt_ecb_inplace(
         &mut self,
@@ -800,7 +800,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     aes::Aes,
     ///     pac,
     ///     rng::{self, Rng},
@@ -820,7 +820,7 @@ impl Aes {
     /// let mut plaintext: [u8; 13] = b"Hello, World!".clone();
     /// let mut tag: [u32; 4] = [0; 4];
     /// aes.encrypt_gcm_inplace(&KEY, &iv, &associated_data, &mut plaintext, &mut tag)?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     pub fn encrypt_gcm_inplace(
         &mut self,
@@ -847,7 +847,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     aes::Aes,
     ///     pac,
     ///     rng::{self, Rng},
@@ -867,7 +867,7 @@ impl Aes {
     /// let mut plaintext: [u32; 1] = [0x12345678];
     /// let mut tag: [u32; 4] = [0; 4];
     /// aes.encrypt_gcm_inplace_u32(&KEY, &iv, &associated_data, &mut plaintext, &mut tag)?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     pub fn encrypt_gcm_inplace_u32(
         &mut self,
@@ -890,7 +890,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -900,7 +900,7 @@ impl Aes {
     /// let ciphertext: [u32; 4] = [0x0336763e, 0x966d9259, 0x5a567cc9, 0xce537f5e];
     /// let mut plaintext: [u32; 4] = [0; 4];
     /// aes.decrypt_ecb(&KEY, &ciphertext, &mut plaintext)?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     pub fn decrypt_ecb(
         &mut self,
@@ -949,7 +949,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -958,7 +958,7 @@ impl Aes {
     ///
     /// let mut text: [u32; 4] = [0x0336763e, 0x966d9259, 0x5a567cc9, 0xce537f5e];
     /// aes.decrypt_ecb_inplace(&KEY, &mut text)?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     pub fn decrypt_ecb_inplace(
         &mut self,
@@ -1008,7 +1008,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -1020,7 +1020,7 @@ impl Aes {
     /// let mut ciphertext: [u8; 5] = [0xf3, 0x44, 0x81, 0xec, 0x3c];
     /// let mut tag: [u32; 4] = [0; 4];
     /// aes.decrypt_gcm_inplace(&KEY, &IV, &associated_data, &mut ciphertext, &mut tag)?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     pub fn decrypt_gcm_inplace(
         &mut self,
@@ -1050,7 +1050,7 @@ impl Aes {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{aes::Aes, pac};
+    /// use stm32wlxx_hal::{aes::Aes, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut aes: Aes = Aes::new(dp.AES, &mut dp.RCC);
@@ -1062,7 +1062,7 @@ impl Aes {
     /// let mut ciphertext: [u32; 1] = [0xf34481ec];
     /// let mut tag: [u32; 4] = [0; 4];
     /// aes.decrypt_gcm_inplace_u32(&KEY, &IV, &associated_data, &mut ciphertext, &mut tag)?;
-    /// # Ok::<(), stm32wl_hal::aes::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::aes::Error>(())
     /// ```
     pub fn decrypt_gcm_inplace_u32(
         &mut self,

--- a/hal/src/dac.rs
+++ b/hal/src/dac.rs
@@ -81,7 +81,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dac::Dac, pac};
+    /// use stm32wlxx_hal::{dac::Dac, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     ///
@@ -110,7 +110,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dac::{Dac, ModeChip},
     ///     pac,
     /// };
@@ -145,7 +145,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dac::Dac, pac};
+    /// use stm32wlxx_hal::{dac::Dac, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let dac = dp.DAC;
@@ -167,7 +167,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// unsafe { stm32wl_hal::dac::Dac::unmask_irq() };
+    /// unsafe { stm32wlxx_hal::dac::Dac::unmask_irq() };
     /// ```
     #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
     pub unsafe fn unmask_irq() {
@@ -179,7 +179,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// stm32wl_hal::dac::Dac::mask_irq();
+    /// stm32wlxx_hal::dac::Dac::mask_irq();
     /// ```
     #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
     pub fn mask_irq() {
@@ -193,7 +193,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dac::Dac, pac};
+    /// use stm32wlxx_hal::{dac::Dac, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// Dac::enable_clock(&mut dp.RCC);
@@ -247,7 +247,7 @@ impl Dac {
     /// Normal mode
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dac::{Dac, ModePin},
     ///     gpio::{Analog, PortA},
     ///     pac,
@@ -263,7 +263,7 @@ impl Dac {
     /// Sample and hold.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dac::{Dac, ModePin},
     ///     gpio::{Analog, PortA},
     ///     pac,
@@ -310,7 +310,7 @@ impl Dac {
     /// Normal mode.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dac::{Dac, ModeChip},
     ///     pac,
     /// };
@@ -323,7 +323,7 @@ impl Dac {
     /// Sample and hold mode.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dac::{Dac, ModeChip},
     ///     pac,
     /// };
@@ -343,7 +343,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dac::{Dac, ModeChip, ModePin},
     ///     gpio::{pins, Analog, PortA},
     ///     pac,
@@ -371,7 +371,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dac::Dac, pac};
+    /// use stm32wlxx_hal::{dac::Dac, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut dac: Dac = Dac::new(dp.DAC, &mut dp.RCC);
@@ -407,7 +407,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dac::Dac, pac};
+    /// use stm32wlxx_hal::{dac::Dac, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut dac: Dac = Dac::new(dp.DAC, &mut dp.RCC);
@@ -430,7 +430,7 @@ impl Dac {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dac::Dac, pac};
+    /// use stm32wlxx_hal::{dac::Dac, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut dac: Dac = Dac::new(dp.DAC, &mut dp.RCC);

--- a/hal/src/dma/cr.rs
+++ b/hal/src/dma/cr.rs
@@ -56,7 +56,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     /// assert_eq!(Cr::RESET.raw(), 0);
     /// ```
     pub const RESET: Cr = Cr::new(0);
@@ -69,7 +69,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     /// assert_eq!(Cr::DISABLE.enabled(), false);
     /// assert_eq!(Cr::DISABLE, Cr::RESET);
     /// ```
@@ -80,7 +80,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     /// const CR: Cr = Cr::new(0x1234_5678);
     /// ```
     pub const fn new(val: u32) -> Cr {
@@ -92,7 +92,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     /// const CR: Cr = Cr::new(0x1234_5678);
     /// assert_eq!(CR.raw(), 0x1234_5678);
     /// ```
@@ -113,7 +113,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.privileged(), false);
@@ -165,7 +165,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.dest_sec(), false);
@@ -220,7 +220,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.src_sec(), false);
@@ -267,7 +267,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.secure(), false);
@@ -313,7 +313,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.mem2mem(), false);
@@ -352,7 +352,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::{Cr, Priority};
+    /// use stm32wlxx_hal::dma::{Cr, Priority};
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.priority(), Priority::Low);
@@ -409,7 +409,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::{Cr, Size};
+    /// use stm32wlxx_hal::dma::{Cr, Size};
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.mem_size(), Some(Size::Bits8));
@@ -459,7 +459,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::{Cr, Size};
+    /// use stm32wlxx_hal::dma::{Cr, Size};
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.periph_size(), Some(Size::Bits8));
@@ -510,7 +510,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.mem_inc(), false);
@@ -560,7 +560,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.periph_inc(), false);
@@ -601,7 +601,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.circ(), false);
@@ -632,7 +632,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::{Cr, Dir};
+    /// use stm32wlxx_hal::dma::{Cr, Dir};
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.dir(), Dir::FromPeriph);
@@ -650,7 +650,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::{Cr, Dir};
+    /// use stm32wlxx_hal::dma::{Cr, Dir};
     ///
     /// let cr = Cr::RESET.set_dir_from_mem();
     /// assert_eq!(cr.dir(), Dir::FromMem);
@@ -668,7 +668,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::{Cr, Dir};
+    /// use stm32wlxx_hal::dma::{Cr, Dir};
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.dir(), Dir::FromPeriph);
@@ -701,7 +701,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.xfer_err_irq_en(), false);
@@ -731,7 +731,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.xfer_hlf_irq_en(), false);
@@ -761,7 +761,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.xfer_cpl_irq_en(), false);
@@ -791,7 +791,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.enabled(), false);
@@ -816,7 +816,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.enabled(), false);
@@ -838,7 +838,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::dma::Cr;
+    /// use stm32wlxx_hal::dma::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.enabled(), false);

--- a/hal/src/dma/mod.rs
+++ b/hal/src/dma/mod.rs
@@ -157,9 +157,9 @@ pub trait DmaCh: sealed::DmaOps {
     /// Check if the transfer is complete.
     ///
     /// ```no_run
-    /// use stm32wl_hal::dma::{flags, DmaCh};
+    /// use stm32wlxx_hal::dma::{flags, DmaCh};
     ///
-    /// # let dma = unsafe { stm32wl_hal::dma::AllDma::steal().d1.c1 };
+    /// # let dma = unsafe { stm32wlxx_hal::dma::AllDma::steal().d1.c1 };
     /// let xfer_cpl: bool = dma.flags() & flags::XFER_CPL != 0;
     /// ```
     fn flags(&self) -> u8;
@@ -173,9 +173,9 @@ pub trait DmaCh: sealed::DmaOps {
     /// Check and clear all set flags.
     ///
     /// ```no_run
-    /// use stm32wl_hal::dma::{flags, DmaCh};
+    /// use stm32wlxx_hal::dma::{flags, DmaCh};
     ///
-    /// # let mut dma = unsafe { stm32wl_hal::dma::AllDma::steal().d1.c1 };
+    /// # let mut dma = unsafe { stm32wlxx_hal::dma::AllDma::steal().d1.c1 };
     /// let flags: u8 = dma.flags();
     /// dma.clear_flags(flags);
     /// ```
@@ -412,7 +412,7 @@ impl AllDma {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dma::AllDma, pac};
+    /// use stm32wlxx_hal::{dma::AllDma, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     ///
@@ -492,7 +492,7 @@ impl AllDma {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dma::AllDma, pac};
+    /// use stm32wlxx_hal::{dma::AllDma, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let dma: AllDma = AllDma::split(dp.DMAMUX, dp.DMA1, dp.DMA2, &mut dp.RCC);
@@ -529,7 +529,7 @@ impl AllDma {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dma::AllDma, pac};
+    /// use stm32wlxx_hal::{dma::AllDma, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     ///
@@ -566,7 +566,7 @@ impl Dma1 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dma::Dma1, pac};
+    /// use stm32wlxx_hal::{dma::Dma1, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     ///
@@ -626,7 +626,7 @@ impl Dma1 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dma::Dma1, pac};
+    /// use stm32wlxx_hal::{dma::Dma1, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let dma1: Dma1 = Dma1::split(dp.DMAMUX, dp.DMA1, &mut dp.RCC);
@@ -658,7 +658,7 @@ impl Dma1 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dma::Dma1, pac};
+    /// use stm32wlxx_hal::{dma::Dma1, pac};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     ///

--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -284,7 +284,7 @@ pub trait Exti {
     /// Set port C as the pin-6 EXTI port.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins::C6, Exti},
     ///     pac,
     /// };
@@ -301,7 +301,7 @@ pub trait Exti {
     /// Set C6 to trigger on a rising edge.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins::C6, Exti},
     ///     pac,
     /// };
@@ -319,7 +319,7 @@ pub trait Exti {
     /// Set C6 to trigger on a falling edge.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins::C6, Exti},
     ///     pac,
     /// };
@@ -340,7 +340,7 @@ pub trait Exti {
     /// Unmask C6.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins::C6, Exti},
     ///     pac,
     /// };
@@ -357,7 +357,7 @@ pub trait Exti {
     ///
     /// See [`gpio-button-irq.rs`].
     ///
-    /// [`gpio-button-irq.rs`]: https://github.com/newAM/stm32wl-hal/blob/main/examples/examples/gpio-button-irq.rs
+    /// [`gpio-button-irq.rs`]: https://github.com/newAM/stm32wlxx-hal/blob/main/examples/examples/gpio-button-irq.rs
     fn clear_exti();
 
     /// Setup an input pin as an EXTI interrupt source on core 1.
@@ -373,7 +373,7 @@ pub trait Exti {
     /// Setup C6 to trigger on both edges.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins::C6, Exti, ExtiTrg},
     ///     pac,
     /// };
@@ -402,7 +402,7 @@ pub trait Exti {
     /// Setup and unmask C6 (which will unmask all pins 5-9).
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins::C6, Exti, ExtiTrg},
     ///     pac,
     /// };
@@ -426,7 +426,7 @@ pub trait Exti {
     /// Mask C6 (which will mask all pins 5-9).
     ///
     /// ```no_run
-    /// use stm32wl_hal::gpio::{pins::C6, Exti};
+    /// use stm32wlxx_hal::gpio::{pins::C6, Exti};
     ///
     /// C6::mask();
     /// ```
@@ -857,7 +857,7 @@ impl PortA {
     /// Get GPIO A0.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortA},
     ///     pac,
     /// };
@@ -893,7 +893,7 @@ impl PortA {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::gpio::PortA;
+    /// use stm32wlxx_hal::gpio::PortA;
     ///
     /// // ... setup happens here
     ///
@@ -992,7 +992,7 @@ impl PortB {
     /// Get GPIO B0.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortB},
     ///     pac,
     /// };
@@ -1028,7 +1028,7 @@ impl PortB {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::gpio::PortB;
+    /// use stm32wlxx_hal::gpio::PortB;
     ///
     /// // ... setup happens here
     ///
@@ -1115,7 +1115,7 @@ impl PortC {
     /// Get GPIO C0.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortC},
     ///     pac,
     /// };
@@ -1151,7 +1151,7 @@ impl PortC {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::gpio::PortC;
+    /// use stm32wlxx_hal::gpio::PortC;
     ///
     /// // ... setup happens here
     ///
@@ -1223,7 +1223,7 @@ impl OutputArgs {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::gpio::OutputArgs;
+    /// use stm32wlxx_hal::gpio::OutputArgs;
     ///
     /// assert_eq!(OutputArgs::new(), OutputArgs::default());
     /// ```
@@ -1263,7 +1263,7 @@ where
     /// These are the GPIOs for the RF switch on the NUCLEO-WL55JC2.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{self, pins, Output, PortC},
     ///     pac,
     /// };
@@ -1307,7 +1307,7 @@ where
     /// Configure GPIO C0 as an output.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Output, OutputArgs, PortC},
     ///     pac,
     /// };
@@ -1335,7 +1335,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::gpio::{pins, Output};
+    /// use stm32wlxx_hal::gpio::{pins, Output};
     ///
     /// // ... setup occurs here
     ///
@@ -1353,7 +1353,7 @@ where
     /// Configure a GPIO as an output, then free it.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Output, PortC},
     ///     pac,
     /// };
@@ -1379,7 +1379,7 @@ where
     /// Pulse a GPIO pin.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Output, PinState, PortC},
     ///     pac,
     /// };
@@ -1406,7 +1406,7 @@ where
     /// Set GPIO C0 high.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Output, PortC},
     ///     pac,
     /// };
@@ -1432,7 +1432,7 @@ where
     /// Set GPIO C0 low.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Output, PortC},
     ///     pac,
     /// };
@@ -1456,7 +1456,7 @@ where
     ///
     /// ```no_run
     /// use core::ops::Not;
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Output, PinState, PortC},
     ///     pac,
     /// };
@@ -1528,7 +1528,7 @@ where
     /// This is the GPIO for button 3 on the NUCLEO-WL55JC2.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Input, PortC, Pull},
     ///     pac,
     /// };
@@ -1553,7 +1553,7 @@ where
     /// Configure GPIO C0 as an input.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Input, PortC},
     ///     pac,
     /// };
@@ -1580,7 +1580,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::gpio::{pins, Input};
+    /// use stm32wlxx_hal::gpio::{pins, Input};
     ///
     /// // ... setup occurs here
     ///
@@ -1598,7 +1598,7 @@ where
     /// Configure a GPIO as an input, then free it.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Input, PortC},
     ///     pac,
     /// };
@@ -1622,7 +1622,7 @@ where
     /// This is the GPIO for button 3 on the NUCLEO-WL55JC2.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Input, PinState, PortC, Pull},
     ///     pac,
     /// };
@@ -1679,7 +1679,7 @@ where
     /// Configure GPIO B14 as an analog pin (ADC_IN1).
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Analog, PortB},
     ///     pac,
     /// };
@@ -1701,7 +1701,7 @@ where
     /// Configure a GPIO as an analog pin, then free it.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, Analog, PortB},
     ///     pac,
     /// };
@@ -1730,7 +1730,7 @@ impl RfBusy {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{PortA, RfBusy},
     ///     pac,
     /// };
@@ -1752,7 +1752,7 @@ impl RfBusy {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortA, RfBusy},
     ///     pac,
     /// };
@@ -1782,7 +1782,7 @@ impl RfIrq0 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{PortB, RfIrq0},
     ///     pac,
     /// };
@@ -1804,7 +1804,7 @@ impl RfIrq0 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortB, RfIrq0},
     ///     pac,
     /// };
@@ -1834,7 +1834,7 @@ impl RfIrq1 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{PortB, RfIrq1},
     ///     pac,
     /// };
@@ -1856,7 +1856,7 @@ impl RfIrq1 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortB, RfIrq1},
     ///     pac,
     /// };
@@ -1886,7 +1886,7 @@ impl RfIrq2 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{PortB, RfIrq2},
     ///     pac,
     /// };
@@ -1908,7 +1908,7 @@ impl RfIrq2 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortB, RfIrq2},
     ///     pac,
     /// };
@@ -1938,7 +1938,7 @@ impl RfNssDbg {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortA, RfNssDbg},
     ///     pac,
     /// };
@@ -1960,7 +1960,7 @@ impl RfNssDbg {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortA, RfNssDbg},
     ///     pac,
     /// };
@@ -1990,7 +1990,7 @@ impl SgSckDbg {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortA, SgSckDbg},
     ///     pac,
     /// };
@@ -2012,7 +2012,7 @@ impl SgSckDbg {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortA, SgSckDbg},
     ///     pac,
     /// };
@@ -2042,7 +2042,7 @@ impl SgMisoDbg {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortA, SgMisoDbg},
     ///     pac,
     /// };
@@ -2064,7 +2064,7 @@ impl SgMisoDbg {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     gpio::{pins, PortA, SgMisoDbg},
     ///     pac,
     /// };
@@ -2094,7 +2094,7 @@ impl SgMosiDbg {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     cortex_m,
     ///     gpio::{pins, PortA, SgMosiDbg},
     ///     pac,
@@ -2117,7 +2117,7 @@ impl SgMosiDbg {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     cortex_m,
     ///     gpio::{pins, PortA, SgMosiDbg},
     ///     pac,

--- a/hal/src/info.rs
+++ b/hal/src/info.rs
@@ -47,7 +47,7 @@ impl Uid {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::info::uid;
+    /// use stm32wlxx_hal::info::uid;
     ///
     /// let coord: u32 = uid().coord();
     /// ```
@@ -60,7 +60,7 @@ impl Uid {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::info::uid;
+    /// use stm32wlxx_hal::info::uid;
     ///
     /// let wafer: u8 = uid().wafer();
     /// ```
@@ -73,7 +73,7 @@ impl Uid {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::info::uid;
+    /// use stm32wlxx_hal::info::uid;
     ///
     /// let lot: [u8; 7] = uid().lot();
     /// ```
@@ -95,7 +95,7 @@ impl Uid {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::info::{uid, Uid};
+/// use stm32wlxx_hal::info::{uid, Uid};
 ///
 /// let uid: Uid = uid();
 /// ```
@@ -116,7 +116,7 @@ pub fn uid() -> Uid {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::info::flash_size_kibibyte;
+/// use stm32wlxx_hal::info::flash_size_kibibyte;
 ///
 /// // valid for the NUCLEO-WL55JC2 dev board
 /// assert_eq!(flash_size_kibibyte(), 256);
@@ -131,7 +131,7 @@ pub fn flash_size_kibibyte() -> u16 {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::info::flash_size;
+/// use stm32wlxx_hal::info::flash_size;
 ///
 /// // valid for the NUCLEO-WL55JC2 dev board
 /// assert_eq!(flash_size(), 256 * 1024);
@@ -183,7 +183,7 @@ impl From<Package> for u8 {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::info;
+/// use stm32wlxx_hal::info;
 ///
 /// let package: Result<info::Package, u8> = info::package();
 /// // valid for the NUCLEO-WL55JC2 dev board
@@ -214,7 +214,7 @@ impl Uid64 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::info::uid64;
+    /// use stm32wlxx_hal::info::uid64;
     ///
     /// let devnum: u32 = uid64().devnum();
     /// ```
@@ -231,7 +231,7 @@ impl Uid64 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::info::uid64;
+    /// use stm32wlxx_hal::info::uid64;
     ///
     /// assert_eq!(uid64().company_id(), 0x0080E1);
     /// ```
@@ -246,7 +246,7 @@ impl Uid64 {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::info::uid64;
+    /// use stm32wlxx_hal::info::uid64;
     ///
     /// assert_eq!(uid64().dev_id(), 0x15);
     /// ```
@@ -285,7 +285,7 @@ pub const UID64: *const u8 = 0x1FFF_7580 as *const u8;
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::info;
+/// use stm32wlxx_hal::info;
 ///
 /// let uid64: info::Uid64 = info::uid64();
 /// assert_eq!(uid64.dev_id(), 0x15);
@@ -304,7 +304,7 @@ pub fn uid64() -> Uid64 {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::info;
+/// use stm32wlxx_hal::info;
 ///
 /// let devnum: u32 = info::uid64_devnum();
 /// ```

--- a/hal/src/lptim/cfgr.rs
+++ b/hal/src/lptim/cfgr.rs
@@ -111,7 +111,7 @@ impl Prescaler {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Prescaler;
+    /// use stm32wlxx_hal::lptim::Prescaler;
     ///
     /// assert_eq!(Prescaler::Div1.div(), 1);
     /// assert_eq!(Prescaler::Div2.div(), 2);
@@ -149,7 +149,7 @@ impl Cfgr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cfgr;
+    /// use stm32wlxx_hal::lptim::Cfgr;
     /// assert_eq!(Cfgr::RESET.raw(), 0);
     /// ```
     pub const RESET: Cfgr = Cfgr::new(0);
@@ -159,7 +159,7 @@ impl Cfgr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cfgr;
+    /// use stm32wlxx_hal::lptim::Cfgr;
     /// const CFGR: Cfgr = Cfgr::new(0);
     /// ```
     pub const fn new(val: u32) -> Cfgr {
@@ -171,7 +171,7 @@ impl Cfgr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cfgr;
+    /// use stm32wlxx_hal::lptim::Cfgr;
     /// const CFGR: Cfgr = Cfgr::new(0x1234_5678);
     /// assert_eq!(CFGR.raw(), 0x1234_5678);
     /// ```
@@ -211,7 +211,7 @@ impl Cfgr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::{Cfgr, Prescaler};
+    /// use stm32wlxx_hal::lptim::{Cfgr, Prescaler};
     ///
     /// assert_eq!(Cfgr::default().prescaler(), Prescaler::default());
     /// ```
@@ -234,7 +234,7 @@ impl Cfgr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::{Cfgr, Prescaler};
+    /// use stm32wlxx_hal::lptim::{Cfgr, Prescaler};
     ///
     /// let cfgr: Cfgr = Cfgr::RESET;
     ///

--- a/hal/src/lptim/cr.rs
+++ b/hal/src/lptim/cr.rs
@@ -11,7 +11,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cr;
+    /// use stm32wlxx_hal::lptim::Cr;
     /// assert_eq!(Cr::RESET.raw(), 0);
     /// ```
     pub const RESET: Cr = Cr::new(0);
@@ -24,7 +24,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cr;
+    /// use stm32wlxx_hal::lptim::Cr;
     /// assert_eq!(Cr::DISABLE.enabled(), false);
     /// assert_eq!(Cr::DISABLE, Cr::RESET);
     /// ```
@@ -35,7 +35,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cr;
+    /// use stm32wlxx_hal::lptim::Cr;
     /// const CR: Cr = Cr::new(0b1);
     /// ```
     pub const fn new(val: u32) -> Cr {
@@ -47,7 +47,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cr;
+    /// use stm32wlxx_hal::lptim::Cr;
     /// const CR: Cr = Cr::new(0x1234_5678);
     /// assert_eq!(CR.raw(), 0x1234_5678);
     /// ```
@@ -88,7 +88,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cr;
+    /// use stm32wlxx_hal::lptim::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.enabled(), false);
@@ -113,7 +113,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cr;
+    /// use stm32wlxx_hal::lptim::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.enabled(), false);
@@ -135,7 +135,7 @@ impl Cr {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::lptim::Cr;
+    /// use stm32wlxx_hal::lptim::Cr;
     ///
     /// let cr = Cr::RESET;
     /// assert_eq!(cr.enabled(), false);

--- a/hal/src/lptim/mod.rs
+++ b/hal/src/lptim/mod.rs
@@ -8,7 +8,7 @@
 //! Setup a one-shot timer.
 //!
 //! ```no_run
-//! use stm32wl_hal::{
+//! use stm32wlxx_hal::{
 //!     embedded_hal::timer::CountDown,
 //!     lptim::{self, LpTim, LpTim1, Prescaler::Div1},
 //!     pac,
@@ -285,7 +285,7 @@ pub trait LpTim: sealed::LpTim {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     lptim::{self, LpTim, LpTim1, Prescaler::Div1},
     ///     pac,
     /// };
@@ -305,7 +305,7 @@ pub trait LpTim: sealed::LpTim {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     lptim::{self, LpTim, LpTim1, Prescaler::Div1},
     ///     pac,
     /// };
@@ -350,7 +350,7 @@ pub trait LpTim: sealed::LpTim {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     lptim::{self, LpTim, LpTim1},
     ///     pac,
     /// };
@@ -366,7 +366,7 @@ pub trait LpTim: sealed::LpTim {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     lptim::{self, LpTim, LpTim1, Prescaler::Div1},
     ///     pac,
     /// };
@@ -408,7 +408,7 @@ pub trait LpTim: sealed::LpTim {
     /// Enable all IRQs.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     lptim::{self, LpTim, LpTim1, Prescaler::Div1},
     ///     pac,
     /// };
@@ -834,7 +834,7 @@ impl LpTim3 {
     /// [`A11`](crate::gpio::pins::A11).
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     cortex_m,
     ///     embedded_hal::timer::CountDown,
     ///     gpio::PortA,
@@ -885,7 +885,7 @@ impl LpTim3 {
     /// Setup a one-shot timer that starts after a transition on pin A11.
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     embedded_hal::timer::CountDown,
     ///     gpio::PortA,
     ///     lptim::{self, Filter, LpTim, LpTim3, LpTim3Trg, Prescaler::Div1, TrgPol},

--- a/hal/src/pka.rs
+++ b/hal/src/pka.rs
@@ -37,7 +37,7 @@
 //! that keypair becomes this:
 //!
 //! ```
-//! use stm32wl_hal::pka::EcdsaPublicKey;
+//! use stm32wlxx_hal::pka::EcdsaPublicKey;
 //!
 //! const PRIV_KEY: [u32; 8] = [
 //!     0x49ac8727, 0xcee87484, 0xfe6dfda5, 0x10238ad4, 0x11ace8fe, 0x593a8cb7, 0x0492d659,
@@ -250,7 +250,7 @@ impl Pka {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{pac, pka::Pka};
+    /// use stm32wlxx_hal::{pac, pka::Pka};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let mut pka = Pka::new(dp.PKA, &mut dp.RCC);
@@ -281,7 +281,7 @@ impl Pka {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{pac, pka::Pka};
+    /// use stm32wlxx_hal::{pac, pka::Pka};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let pka: pac::PKA = dp.PKA;
@@ -308,7 +308,7 @@ impl Pka {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::pka::Pka;
+    /// use stm32wlxx_hal::pka::Pka;
     ///
     /// // ... setup happens here
     ///
@@ -367,7 +367,7 @@ impl Pka {
     ///
     /// ```no_run
     /// # #[cfg(not(feature = "stm32wl5x_cm0p"))]
-    /// unsafe { stm32wl_hal::pka::Pka::unmask_irq() };
+    /// unsafe { stm32wlxx_hal::pka::Pka::unmask_irq() };
     /// ```
     #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
     #[inline]
@@ -431,8 +431,8 @@ impl Pka {
     /// [`ecdsa_sign_result`](Self::ecdsa_sign_result).
     ///
     /// ```no_run
-    /// # let mut pka = unsafe { stm32wl_hal::pka::Pka::steal() };
-    /// # let curve = stm32wl_hal::pka::curve::NIST_P256;
+    /// # let mut pka = unsafe { stm32wlxx_hal::pka::Pka::steal() };
+    /// # let curve = stm32wlxx_hal::pka::curve::NIST_P256;
     /// # let nonce: [u32; 8] = [0; 8];
     /// # let priv_key: [u32; 8] = [0; 8];
     /// # let hash: [u32; 8] = [0; 8];
@@ -444,7 +444,7 @@ impl Pka {
     /// // non-blocking
     /// pka.ecdsa_sign_start(&curve, &nonce, &priv_key, &hash)?;
     /// nb::block!(pka.ecdsa_sign_result(&mut r_sign, &mut s_sign))?;
-    /// # Ok::<(), stm32wl_hal::pka::EcdsaSignError>(())
+    /// # Ok::<(), stm32wlxx_hal::pka::EcdsaSignError>(())
     /// ```
     ///
     /// # Computation Times
@@ -563,14 +563,14 @@ impl Pka {
     /// [`ecdsa_verify_result`](Self::ecdsa_verify_result).
     ///
     /// ```no_run
-    /// # let mut pka = unsafe { stm32wl_hal::pka::Pka::steal() };
-    /// # let curve = stm32wl_hal::pka::curve::NIST_P256;
+    /// # let mut pka = unsafe { stm32wlxx_hal::pka::Pka::steal() };
+    /// # let curve = stm32wlxx_hal::pka::curve::NIST_P256;
     /// # let r_sign: [u32; 8] = [0; 8];
     /// # let s_sign: [u32; 8] = [0; 8];
     /// # let curve_pt_x: [u32; 8] = [0; 8];
     /// # let curve_pt_y: [u32; 8] = [0; 8];
-    /// # let sig = stm32wl_hal::pka::EcdsaSignature { r_sign: &r_sign, s_sign: &s_sign };
-    /// # let pub_key = stm32wl_hal::pka::EcdsaPublicKey { curve_pt_x: &curve_pt_x, curve_pt_y: &curve_pt_y };
+    /// # let sig = stm32wlxx_hal::pka::EcdsaSignature { r_sign: &r_sign, s_sign: &s_sign };
+    /// # let pub_key = stm32wlxx_hal::pka::EcdsaPublicKey { curve_pt_x: &curve_pt_x, curve_pt_y: &curve_pt_y };
     /// # let hash: [u32; 8] = [0; 8];
     /// // blocking
     /// pka.ecdsa_verify(&curve, &sig, &pub_key, &hash)?;
@@ -578,7 +578,7 @@ impl Pka {
     /// // non-blocking
     /// pka.ecdsa_verify_start(&curve, &sig, &pub_key, &hash)?;
     /// nb::block!(pka.ecdsa_verify_result())?;
-    /// # Ok::<(), stm32wl_hal::pka::EcdsaVerifyError>(())
+    /// # Ok::<(), stm32wlxx_hal::pka::EcdsaVerifyError>(())
     /// ```
     ///
     /// # Computation Times

--- a/hal/src/pwr.rs
+++ b/hal/src/pwr.rs
@@ -50,7 +50,7 @@ impl WakeupPin {
 /// Enable A0 to wakeup on a falling edge.
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     pac,
 ///     pwr::{setup_wakeup_pins, WakeupPin},
 /// };
@@ -96,7 +96,7 @@ pub fn setup_wakeup_pins(pwr: &mut pac::PWR, wp1: WakeupPin, wp2: WakeupPin, wp3
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, pwr::shutdown};
+/// use stm32wlxx_hal::{pac, pwr::shutdown};
 ///
 /// let mut cp: pac::CorePeripherals = pac::CorePeripherals::take().unwrap();
 /// // SLEEPDEEP is implemented with retention
@@ -132,7 +132,7 @@ pub fn shutdown() -> ! {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, pwr::enable_shutdown_sleeponexit};
+/// use stm32wlxx_hal::{pac, pwr::enable_shutdown_sleeponexit};
 ///
 /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 /// let mut cp: pac::CorePeripherals = pac::CorePeripherals::take().unwrap();
@@ -158,7 +158,7 @@ pub fn enable_shutdown_sleeponexit(pwr: &mut pac::PWR, scb: &mut pac::SCB) {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, pwr::enable_shutdown};
+/// use stm32wlxx_hal::{pac, pwr::enable_shutdown};
 ///
 /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 /// let mut cp: pac::CorePeripherals = pac::CorePeripherals::take().unwrap();
@@ -216,7 +216,7 @@ impl From<LprunRange> for MsiRange {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     pac,
 ///     pwr::{enter_lprun_msi, LprunRange},
 /// };
@@ -252,7 +252,7 @@ pub unsafe fn enter_lprun_msi(
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     pac,
 ///     pwr::{enter_lprun_msi, exit_lprun, LprunRange},
 /// };

--- a/hal/src/rcc.rs
+++ b/hal/src/rcc.rs
@@ -76,7 +76,7 @@ impl MsiRange {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::rcc::MsiRange;
+    /// use stm32wlxx_hal::rcc::MsiRange;
     ///
     /// assert_eq!(MsiRange::Range100k.to_hz(), 100_000);
     /// assert_eq!(MsiRange::Range200k.to_hz(), 200_000);
@@ -253,7 +253,7 @@ const fn ppre_div(pre: u8) -> u8 {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     pac,
 ///     rcc::{set_sysclk_hse, Vos},
 /// };
@@ -330,7 +330,7 @@ pub unsafe fn set_sysclk_hse(
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::set_sysclk_hsi};
+/// use stm32wlxx_hal::{pac, rcc::set_sysclk_hsi};
 ///
 /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 /// cortex_m::interrupt::free(|cs| unsafe {
@@ -376,7 +376,7 @@ pub unsafe fn set_sysclk_hsi(
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     pac,
 ///     rcc::{set_sysclk_msi, MsiRange},
 /// };
@@ -499,7 +499,7 @@ unsafe fn set_sysclk_msi_inner(
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::set_sysclk_msi_max};
+/// use stm32wlxx_hal::{pac, rcc::set_sysclk_msi_max};
 ///
 /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 /// cortex_m::interrupt::free(|cs| unsafe {
@@ -598,7 +598,7 @@ pub(crate) fn sysclk(rcc: &pac::RCC, cfgr: &pac::rcc::cfgr::R) -> Ratio<u32> {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::sysclk_hz};
+/// use stm32wlxx_hal::{pac, rcc::sysclk_hz};
 ///
 /// let dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 ///
@@ -622,7 +622,7 @@ fn hclk1(rcc: &pac::RCC, cfgr: &pac::rcc::cfgr::R) -> Ratio<u32> {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::hclk1_hz};
+/// use stm32wlxx_hal::{pac, rcc::hclk1_hz};
 ///
 /// let dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 ///
@@ -647,7 +647,7 @@ fn hclk2(rcc: &pac::RCC, cfgr: &pac::rcc::cfgr::R) -> Ratio<u32> {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::hclk2_hz};
+/// use stm32wlxx_hal::{pac, rcc::hclk2_hz};
 ///
 /// let dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 ///
@@ -672,7 +672,7 @@ pub(crate) fn hclk3(rcc: &pac::RCC, cfgr: &pac::rcc::cfgr::R) -> Ratio<u32> {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::hclk3_hz};
+/// use stm32wlxx_hal::{pac, rcc::hclk3_hz};
 ///
 /// let dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 ///
@@ -719,7 +719,7 @@ pub(crate) fn apb1timx(rcc: &pac::RCC) -> Ratio<u32> {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::pclk1_hz};
+/// use stm32wlxx_hal::{pac, rcc::pclk1_hz};
 ///
 /// let dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 ///
@@ -743,7 +743,7 @@ pub(crate) fn pclk2(rcc: &pac::RCC, cfgr: &pac::rcc::cfgr::R) -> Ratio<u32> {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::pclk2_hz};
+/// use stm32wlxx_hal::{pac, rcc::pclk2_hz};
 ///
 /// let dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 ///
@@ -764,7 +764,7 @@ pub fn pclk2_hz(rcc: &pac::RCC) -> u32 {
 /// Created a systick based delay structure.
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     cortex_m::{delay::Delay, peripheral::syst::SystClkSource},
 ///     pac,
 ///     rcc::cpu1_systick_hz,
@@ -802,7 +802,7 @@ fn cpu2_systick(rcc: &pac::RCC, cfgr: pac::rcc::cfgr::R, src: SystClkSource) -> 
 /// Created a systick based delay structure.
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     cortex_m::{delay::Delay, peripheral::syst::SystClkSource},
 ///     pac,
 ///     rcc::cpu2_systick_hz,
@@ -833,7 +833,7 @@ pub fn cpu2_systick_hz(rcc: &pac::RCC, src: SystClkSource) -> u32 {
 /// Created a systick based delay structure.
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     cortex_m::{delay::Delay, peripheral::syst::SystClkSource},
 ///     pac,
 ///     rcc::cpu_systick_hz,
@@ -866,7 +866,7 @@ pub fn cpu_systick_hz(rcc: &pac::RCC, src: SystClkSource) -> u32 {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::lsi_hz};
+/// use stm32wlxx_hal::{pac, rcc::lsi_hz};
 ///
 /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 ///
@@ -899,7 +899,7 @@ pub fn lsi_hz(rcc: &pac::RCC) -> u16 {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     pac,
 ///     rcc::{setup_lsi, LsiPre},
 /// };
@@ -925,7 +925,7 @@ pub unsafe fn setup_lsi(rcc: &mut pac::RCC, pre: LsiPre) {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::enable_lsi};
+/// use stm32wlxx_hal::{pac, rcc::enable_lsi};
 ///
 /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 /// enable_lsi(&mut dp.RCC);
@@ -948,7 +948,7 @@ pub fn enable_lsi(rcc: &mut pac::RCC) {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, rcc::pulse_reset_backup_domain};
+/// use stm32wlxx_hal::{pac, rcc::pulse_reset_backup_domain};
 ///
 /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
 /// unsafe { pulse_reset_backup_domain(&mut dp.RCC, &mut dp.PWR) };

--- a/hal/src/rng.rs
+++ b/hal/src/rng.rs
@@ -70,7 +70,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -130,7 +130,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -165,7 +165,7 @@ impl Rng {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::rng::Rng;
+    /// use stm32wlxx_hal::rng::Rng;
     ///
     /// // ... setup happens here
     ///
@@ -191,7 +191,7 @@ impl Rng {
     ///
     /// ```no_run
     /// # #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
-    /// unsafe { stm32wl_hal::rng::Rng::unmask_irq() };
+    /// unsafe { stm32wlxx_hal::rng::Rng::unmask_irq() };
     /// ```
     #[cfg(all(not(feature = "stm32wl5x_cm0p"), feature = "rt"))]
     pub unsafe fn unmask_irq() {
@@ -251,7 +251,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -261,7 +261,7 @@ impl Rng {
     ///
     /// let mut nonce: [u32; 4] = [0; 4];
     /// rng.try_fill_u32(&mut nonce)?;
-    /// # Ok::<(), stm32wl_hal::rng::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::rng::Error>(())
     /// ```
     pub fn try_fill_u32(&mut self, dest: &mut [u32]) -> Result<(), Error> {
         for dw in dest {
@@ -275,7 +275,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -285,7 +285,7 @@ impl Rng {
     ///
     /// let mut nonce: [u8; 16] = [0; 16];
     /// rng.try_fill_u8(&mut nonce)?;
-    /// # Ok::<(), stm32wl_hal::rng::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::rng::Error>(())
     /// ```
     pub fn try_fill_u8(&mut self, dest: &mut [u8]) -> Result<(), Error> {
         for chunk in dest.chunks_mut(4) {
@@ -311,7 +311,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -320,7 +320,7 @@ impl Rng {
     /// let mut rng = Rng::new(dp.RNG, Clk::MSI, &mut dp.RCC);
     ///
     /// let rand_value: u8 = rng.try_u8()?;
-    /// # Ok::<(), stm32wl_hal::rng::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::rng::Error>(())
     /// ```
     pub fn try_u8(&mut self) -> Result<u8, Error> {
         Ok(self.try_u32()? as u8)
@@ -336,7 +336,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -345,7 +345,7 @@ impl Rng {
     /// let mut rng = Rng::new(dp.RNG, Clk::MSI, &mut dp.RCC);
     ///
     /// let rand_value: u16 = rng.try_u16()?;
-    /// # Ok::<(), stm32wl_hal::rng::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::rng::Error>(())
     /// ```
     pub fn try_u16(&mut self) -> Result<u16, Error> {
         Ok(self.try_u32()? as u16)
@@ -361,7 +361,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -370,7 +370,7 @@ impl Rng {
     /// let mut rng = Rng::new(dp.RNG, Clk::MSI, &mut dp.RCC);
     ///
     /// let rand_value: u32 = rng.try_u32()?;
-    /// # Ok::<(), stm32wl_hal::rng::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::rng::Error>(())
     /// ```
     pub fn try_u32(&mut self) -> Result<u32, Error> {
         // reference manual recommends verifying DR is non-zero for
@@ -390,7 +390,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -399,7 +399,7 @@ impl Rng {
     /// let mut rng = Rng::new(dp.RNG, Clk::MSI, &mut dp.RCC);
     ///
     /// let rand_value: u64 = rng.try_u64()?;
-    /// # Ok::<(), stm32wl_hal::rng::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::rng::Error>(())
     /// ```
     pub fn try_u64(&mut self) -> Result<u64, Error> {
         let mut buf: [u8; 8] = [0; 8];
@@ -417,7 +417,7 @@ impl Rng {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rng::{Clk, Rng},
     /// };
@@ -426,7 +426,7 @@ impl Rng {
     /// let mut rng = Rng::new(dp.RNG, Clk::MSI, &mut dp.RCC);
     ///
     /// let rand_value: u128 = rng.try_u128()?;
-    /// # Ok::<(), stm32wl_hal::rng::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::rng::Error>(())
     /// ```
     pub fn try_u128(&mut self) -> Result<u128, Error> {
         let mut buf: [u8; 16] = [0; 16];

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -73,7 +73,7 @@ impl Rtc {
     /// LSE clock source (this depends on HW, example valid for NUCLEO board):
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rcc::pulse_reset_backup_domain,
     ///     rtc::{Clk, Rtc},
@@ -92,7 +92,7 @@ impl Rtc {
     /// LSI clock source:
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rcc::{enable_lsi, pulse_reset_backup_domain},
     ///     rtc::{Clk, Rtc},
@@ -109,7 +109,7 @@ impl Rtc {
     /// HSE clock source (this depends on HW, example valid for NUCLEO board):
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     rcc::pulse_reset_backup_domain,
     ///     rtc::{Clk, Rtc},
@@ -466,7 +466,7 @@ impl Rtc {
     /// Setup the wakeup timer to go off in 1 hour, without interrupts.
     ///
     /// ```no_run
-    /// # use stm32wl_hal::{pac, rtc};
+    /// # use stm32wlxx_hal::{pac, rtc};
     /// # let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// # let mut rtc = rtc::Rtc::new(dp.RTC, rtc::Clk::Lse, &mut dp.PWR, &mut dp.RCC);
     /// rtc.setup_wakeup_timer(3599, false);

--- a/hal/src/spi.rs
+++ b/hal/src/spi.rs
@@ -113,7 +113,7 @@ impl BaudRate {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::spi::BaudRate;
+    /// use stm32wlxx_hal::spi::BaudRate;
     ///
     /// assert_eq!(BaudRate::Div256.div(), 256);
     /// assert_eq!(BaudRate::Div128.div(), 128);
@@ -538,7 +538,7 @@ impl<SCK, MISO, MOSI, MODE> Spi<pac::SPI1, SCK, MISO, MOSI, MODE> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     spi::{Master, NoMiso, NoMosi, NoSck, Spi},
     /// };
@@ -567,7 +567,7 @@ impl<SCK, MISO, MOSI, MODE> Spi<pac::SPI1, SCK, MISO, MOSI, MODE> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     spi::{Master, NoMiso, NoMosi, NoSck, Spi},
     /// };
@@ -587,7 +587,7 @@ impl<SCK, MISO, MOSI, MODE> Spi<pac::SPI1, SCK, MISO, MOSI, MODE> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     spi::{Master, NoMiso, NoMosi, NoSck, Spi},
     /// };
@@ -613,7 +613,7 @@ impl<SCK, MISO, MOSI, MODE> Spi<pac::SPI2, SCK, MISO, MOSI, MODE> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     spi::{Master, NoMiso, NoMosi, NoSck, Spi},
     /// };
@@ -642,7 +642,7 @@ impl<SCK, MISO, MOSI, MODE> Spi<pac::SPI2, SCK, MISO, MOSI, MODE> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     spi::{Master, NoMiso, NoMosi, NoSck, Spi},
     /// };
@@ -662,7 +662,7 @@ impl<SCK, MISO, MOSI, MODE> Spi<pac::SPI2, SCK, MISO, MOSI, MODE> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     spi::{Master, NoMiso, NoMosi, NoSck, Spi},
     /// };
@@ -712,7 +712,7 @@ macro_rules! impl_new_full_duplex {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     gpio::PortA,
                 ///     pac,
@@ -791,7 +791,7 @@ macro_rules! impl_new_full_duplex_slave {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     gpio::PortA,
                 ///     pac,
@@ -868,7 +868,7 @@ macro_rules! impl_new_full_duplex_dma {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     dma::AllDma,
                 ///     gpio::PortA,
@@ -964,7 +964,7 @@ macro_rules! impl_new_full_duplex_slave_dma {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     dma::AllDma,
                 ///     gpio::PortA,
@@ -1053,7 +1053,7 @@ macro_rules! impl_new_mosi_simplex {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     gpio::PortA,
                 ///     pac,
@@ -1132,7 +1132,7 @@ macro_rules! impl_new_mosi_simplex_slave {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     gpio::PortA,
                 ///     pac,
@@ -1207,7 +1207,7 @@ macro_rules! impl_new_mosi_simplex_dma {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     dma::AllDma,
                 ///     gpio::PortA,
@@ -1296,7 +1296,7 @@ macro_rules! impl_new_mosi_simplex_slave_dma {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     dma::AllDma,
                 ///     gpio::PortA,
@@ -1379,7 +1379,7 @@ macro_rules! impl_new_miso_simplex {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     gpio::PortA,
                 ///     pac,
@@ -1455,7 +1455,7 @@ macro_rules! impl_new_miso_simplex_dma {
                 /// # Example
                 ///
                 /// ```no_run
-                /// use stm32wl_hal::{
+                /// use stm32wlxx_hal::{
                 ///     cortex_m,
                 ///     dma::AllDma,
                 ///     gpio::PortA,
@@ -1628,7 +1628,7 @@ impl<SPI: SpiRegs, SCK, MISO, MOSI> Spi<SPI, SCK, MISO, MOSI, Slave> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dma::AllDma,
     ///     gpio::PortA,
     ///     pac,
@@ -1669,7 +1669,7 @@ impl<SPI, SCK, MISO, MOSI, MODE> Spi<SPI, SCK, MISO, MOSI, MODE> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dma::AllDma,
     ///     gpio::PortA,
     ///     pac,

--- a/hal/src/subghz/bit_sync.rs
+++ b/hal/src/subghz/bit_sync.rs
@@ -33,7 +33,7 @@ impl BitSync {
     /// Enable simple bit synchronization.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BitSync;
+    /// use stm32wlxx_hal::subghz::BitSync;
     ///
     /// const BIT_SYNC: BitSync = BitSync::RESET.set_simple_bit_sync_en(true);
     /// # assert_eq!(u8::from(BIT_SYNC), 0x40u8);
@@ -53,7 +53,7 @@ impl BitSync {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BitSync;
+    /// use stm32wlxx_hal::subghz::BitSync;
     ///
     /// let bs: BitSync = BitSync::RESET;
     /// assert_eq!(bs.simple_bit_sync_en(), false);
@@ -73,7 +73,7 @@ impl BitSync {
     /// Invert receive data.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BitSync;
+    /// use stm32wlxx_hal::subghz::BitSync;
     ///
     /// const BIT_SYNC: BitSync = BitSync::RESET.set_rx_data_inv(true);
     /// # assert_eq!(u8::from(BIT_SYNC), 0x20u8);
@@ -93,7 +93,7 @@ impl BitSync {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BitSync;
+    /// use stm32wlxx_hal::subghz::BitSync;
     ///
     /// let bs: BitSync = BitSync::RESET;
     /// assert_eq!(bs.rx_data_inv(), false);
@@ -113,7 +113,7 @@ impl BitSync {
     /// Enable normal bit synchronization.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BitSync;
+    /// use stm32wlxx_hal::subghz::BitSync;
     ///
     /// const BIT_SYNC: BitSync = BitSync::RESET.set_norm_bit_sync_en(true);
     /// # assert_eq!(u8::from(BIT_SYNC), 0x10u8);
@@ -133,7 +133,7 @@ impl BitSync {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BitSync;
+    /// use stm32wlxx_hal::subghz::BitSync;
     ///
     /// let bs: BitSync = BitSync::RESET;
     /// assert_eq!(bs.norm_bit_sync_en(), false);

--- a/hal/src/subghz/cad_params.rs
+++ b/hal/src/subghz/cad_params.rs
@@ -75,7 +75,7 @@ impl CadParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::CadParams;
+    /// use stm32wlxx_hal::subghz::CadParams;
     ///
     /// const CAD_PARAMS: CadParams = CadParams::new();
     /// assert_eq!(CAD_PARAMS, CadParams::default());
@@ -97,7 +97,7 @@ impl CadParams {
     /// Set the number of symbols to 4.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CadParams, NbCadSymbol};
+    /// use stm32wlxx_hal::subghz::{CadParams, NbCadSymbol};
     ///
     /// const CAD_PARAMS: CadParams = CadParams::new().set_num_symbol(NbCadSymbol::S4);
     /// # assert_eq!(CAD_PARAMS.as_slice()[1], 0x2);
@@ -117,7 +117,7 @@ impl CadParams {
     /// Setting the recommended value for a spreading factor of 7.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::CadParams;
+    /// use stm32wlxx_hal::subghz::CadParams;
     ///
     /// const CAD_PARAMS: CadParams = CadParams::new().set_det_peak(0x20).set_det_min(0x10);
     /// # assert_eq!(CAD_PARAMS.as_slice()[2], 0x20);
@@ -140,7 +140,7 @@ impl CadParams {
     /// Setting the recommended value for a spreading factor of 6.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::CadParams;
+    /// use stm32wlxx_hal::subghz::CadParams;
     ///
     /// const CAD_PARAMS: CadParams = CadParams::new().set_det_peak(0x18).set_det_min(0x10);
     /// # assert_eq!(CAD_PARAMS.as_slice()[2], 0x18);
@@ -159,7 +159,7 @@ impl CadParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CadParams, ExitMode};
+    /// use stm32wlxx_hal::subghz::{CadParams, ExitMode};
     ///
     /// const CAD_PARAMS: CadParams = CadParams::new().set_exit_mode(ExitMode::Standby);
     /// # assert_eq!(CAD_PARAMS.as_slice()[4], 0x00);
@@ -178,7 +178,7 @@ impl CadParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CadParams, ExitMode, Timeout};
+    /// use stm32wlxx_hal::subghz::{CadParams, ExitMode, Timeout};
     ///
     /// const TIMEOUT: Timeout = Timeout::from_raw(0x123456);
     /// const CAD_PARAMS: CadParams = CadParams::new()
@@ -203,7 +203,7 @@ impl CadParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CadParams, ExitMode, NbCadSymbol, Timeout};
+    /// use stm32wlxx_hal::subghz::{CadParams, ExitMode, NbCadSymbol, Timeout};
     ///
     /// const TIMEOUT: Timeout = Timeout::from_raw(0x123456);
     /// const CAD_PARAMS: CadParams = CadParams::new()

--- a/hal/src/subghz/calibrate.rs
+++ b/hal/src/subghz/calibrate.rs
@@ -28,7 +28,7 @@ impl CalibrateImage {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::CalibrateImage;
+    /// use stm32wlxx_hal::subghz::CalibrateImage;
     ///
     /// const CAL: CalibrateImage = CalibrateImage::new(0xE1, 0xE9);
     /// assert_eq!(CAL, CalibrateImage::ISM_902_928);
@@ -54,7 +54,7 @@ impl CalibrateImage {
     /// Create an image calibration for the 430 - 440 MHz ISM band.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::CalibrateImage;
+    /// use stm32wlxx_hal::subghz::CalibrateImage;
     ///
     /// let cal: CalibrateImage = CalibrateImage::from_freq(428, 444);
     /// assert_eq!(cal, CalibrateImage::ISM_430_440);
@@ -106,7 +106,7 @@ impl Calibrate {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Calibrate;
+    /// use stm32wlxx_hal::subghz::Calibrate;
     ///
     /// assert_eq!(Calibrate::Image.mask(), 0b0100_0000);
     /// assert_eq!(Calibrate::AdcBulkP.mask(), 0b0010_0000);

--- a/hal/src/subghz/fallback_mode.rs
+++ b/hal/src/subghz/fallback_mode.rs
@@ -27,7 +27,7 @@ impl Default for FallbackMode {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FallbackMode;
+    /// use stm32wlxx_hal::subghz::FallbackMode;
     ///
     /// assert_eq!(FallbackMode::default(), FallbackMode::Standby);
     /// ```

--- a/hal/src/subghz/hse_trim.rs
+++ b/hal/src/subghz/hse_trim.rs
@@ -26,7 +26,7 @@ impl HseTrim {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::HseTrim;
+    /// use stm32wlxx_hal::subghz::HseTrim;
     ///
     /// assert_eq!(HseTrim::POR, HseTrim::default());
     /// ```
@@ -39,7 +39,7 @@ impl HseTrim {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::HseTrim;
+    /// use stm32wlxx_hal::subghz::HseTrim;
     ///
     /// assert_eq!(HseTrim::from_raw(0xFF), HseTrim::MAX);
     /// assert_eq!(HseTrim::from_raw(0x2F), HseTrim::MAX);
@@ -61,7 +61,7 @@ impl HseTrim {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::HseTrim;
+    /// use stm32wlxx_hal::subghz::HseTrim;
     ///
     /// assert!(HseTrim::from_farads(1.0).is_err());
     /// assert!(HseTrim::from_farads(1e-12).is_err());
@@ -84,7 +84,7 @@ impl HseTrim {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::HseTrim;
+    /// use stm32wlxx_hal::subghz::HseTrim;
     ///
     /// assert_eq!((HseTrim::MAX.as_farads() * 10e11) as u8, 33);
     /// assert_eq!((HseTrim::MIN.as_farads() * 10e11) as u8, 11);

--- a/hal/src/subghz/irq.rs
+++ b/hal/src/subghz/irq.rs
@@ -99,7 +99,7 @@ impl Irq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Irq;
+    /// use stm32wlxx_hal::subghz::Irq;
     ///
     /// assert_eq!(Irq::TxDone.mask(), 0x0001);
     /// assert_eq!(Irq::Timeout.mask(), 0x0200);
@@ -128,7 +128,7 @@ impl CfgIrq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::CfgIrq;
+    /// use stm32wlxx_hal::subghz::CfgIrq;
     ///
     /// const IRQ_CFG: CfgIrq = CfgIrq::new();
     /// ```
@@ -153,7 +153,7 @@ impl CfgIrq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CfgIrq, Irq, IrqLine};
+    /// use stm32wlxx_hal::subghz::{CfgIrq, Irq, IrqLine};
     ///
     /// const IRQ_CFG: CfgIrq = CfgIrq::new()
     ///     .irq_enable(IrqLine::Global, Irq::TxDone)
@@ -179,7 +179,7 @@ impl CfgIrq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CfgIrq, Irq};
+    /// use stm32wlxx_hal::subghz::{CfgIrq, Irq};
     ///
     /// const IRQ_CFG: CfgIrq = CfgIrq::new()
     ///     .irq_enable_all(Irq::TxDone)
@@ -214,7 +214,7 @@ impl CfgIrq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CfgIrq, Irq, IrqLine};
+    /// use stm32wlxx_hal::subghz::{CfgIrq, Irq, IrqLine};
     ///
     /// const IRQ_CFG: CfgIrq = CfgIrq::new()
     ///     .irq_enable(IrqLine::Global, Irq::TxDone)
@@ -239,7 +239,7 @@ impl CfgIrq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CfgIrq, Irq};
+    /// use stm32wlxx_hal::subghz::{CfgIrq, Irq};
     ///
     /// const IRQ_CFG: CfgIrq = CfgIrq::new()
     ///     .irq_enable_all(Irq::TxDone)
@@ -269,7 +269,7 @@ impl CfgIrq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CfgIrq, Irq};
+    /// use stm32wlxx_hal::subghz::{CfgIrq, Irq};
     ///
     /// const IRQ_CFG: CfgIrq = CfgIrq::new()
     ///     .irq_enable_all(Irq::TxDone)

--- a/hal/src/subghz/mod.rs
+++ b/hal/src/subghz/mod.rs
@@ -165,7 +165,7 @@ pub unsafe fn wakeup() {
 /// # Example
 ///
 /// ```no_run
-/// unsafe { stm32wl_hal::subghz::unmask_irq() };
+/// unsafe { stm32wlxx_hal::subghz::unmask_irq() };
 /// ```
 #[inline]
 pub unsafe fn unmask_irq() {
@@ -177,7 +177,7 @@ pub unsafe fn unmask_irq() {
 /// # Example
 ///
 /// ```no_run
-/// stm32wl_hal::subghz::mask_irq();
+/// stm32wlxx_hal::subghz::mask_irq();
 /// ```
 #[inline]
 pub fn mask_irq() {
@@ -214,7 +214,7 @@ pub fn rfbusyms() -> bool {
 ///
 /// ```no_run
 /// use static_assertions as sa;
-/// use stm32wl_hal::{
+/// use stm32wlxx_hal::{
 ///     dma::{AllDma, Dma1Ch1, Dma1Ch2},
 ///     pac,
 ///     subghz::{
@@ -285,14 +285,14 @@ pub fn rfbusyms() -> bool {
 /// sg.calibrate_image(CalibrateImage::ISM_430_440)?;
 /// sg.set_rf_frequency(&RF_FREQ)?;
 /// sg.set_irq_cfg(&IRQ_CFG)?;
-/// # Ok::<(), stm32wl_hal::subghz::Error>(())
+/// # Ok::<(), stm32wlxx_hal::subghz::Error>(())
 /// ```
 ///
 /// Basic RX, requires setup.
 ///
 /// ```no_run
-/// # let mut sg = unsafe { stm32wl_hal::subghz::SubGhz::steal() };
-/// use stm32wl_hal::subghz::{Irq, Timeout};
+/// # let mut sg = unsafe { stm32wlxx_hal::subghz::SubGhz::steal() };
+/// use stm32wlxx_hal::subghz::{Irq, Timeout};
 ///
 /// // if you have an RF switch put it into RX mode on this line
 /// sg.set_rx(Timeout::DISABLED)?;
@@ -313,15 +313,15 @@ pub fn rfbusyms() -> bool {
 ///         // ... handle other IRQs
 ///     }
 /// }
-/// # Ok::<(), stm32wl_hal::subghz::Error>(())
+/// # Ok::<(), stm32wlxx_hal::subghz::Error>(())
 /// ```
 ///
 /// Basic TX, requires setup.
 ///
 /// ```no_run
 /// # const TX_BUF_OFFSET: u8 = 0;
-/// # let mut sg = unsafe { stm32wl_hal::subghz::SubGhz::steal() };
-/// use stm32wl_hal::subghz::{Irq, Timeout};
+/// # let mut sg = unsafe { stm32wlxx_hal::subghz::SubGhz::steal() };
+/// use stm32wlxx_hal::subghz::{Irq, Timeout};
 ///
 /// sg.write_buffer(TX_BUF_OFFSET, b"Hello, World!")?;
 /// // if you have an RF switch put it into TX mode on this line
@@ -339,7 +339,7 @@ pub fn rfbusyms() -> bool {
 ///         // ... handle other IRQs
 ///     }
 /// }
-/// # Ok::<(), stm32wl_hal::subghz::Error>(())
+/// # Ok::<(), stm32wlxx_hal::subghz::Error>(())
 /// ```
 #[derive(Debug)]
 pub struct SubGhz<MISO, MOSI> {
@@ -394,7 +394,7 @@ impl<MISO, MOSI> SubGhz<MISO, MOSI> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{pac, subghz::SubGhz};
+    /// use stm32wlxx_hal::{pac, subghz::SubGhz};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let sg = SubGhz::new(dp.SPI3, &mut dp.RCC);
@@ -455,7 +455,7 @@ impl SubGhz<SgMiso, SgMosi> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{pac, subghz::SubGhz};
+    /// use stm32wlxx_hal::{pac, subghz::SubGhz};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     /// let sg = SubGhz::new(dp.SPI3, &mut dp.RCC);
@@ -484,7 +484,7 @@ impl SubGhz<SgMiso, SgMosi> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::SubGhz;
+    /// use stm32wlxx_hal::subghz::SubGhz;
     ///
     /// // ... setup happens here
     ///
@@ -507,7 +507,7 @@ impl<MISO: DmaCh, MOSI: DmaCh> SubGhz<MISO, MOSI> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{dma::AllDma, pac, subghz::SubGhz};
+    /// use stm32wlxx_hal::{dma::AllDma, pac, subghz::SubGhz};
     ///
     /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
     ///
@@ -546,7 +546,7 @@ impl<MISO: DmaCh, MOSI: DmaCh> SubGhz<MISO, MOSI> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     dma::{AllDma, Dma1Ch1, Dma2Ch1},
     ///     subghz::SubGhz,
     /// };
@@ -776,11 +776,11 @@ where
     /// Put the radio into sleep mode.
     ///
     /// ```no_run
-    /// # let cp = unsafe { stm32wl_hal::pac::CorePeripherals::steal() };
-    /// # let dp = unsafe { stm32wl_hal::pac::Peripherals::steal() };
-    /// # let mut sg = unsafe { stm32wl_hal::subghz::SubGhz::steal() };
+    /// # let cp = unsafe { stm32wlxx_hal::pac::CorePeripherals::steal() };
+    /// # let dp = unsafe { stm32wlxx_hal::pac::Peripherals::steal() };
+    /// # let mut sg = unsafe { stm32wlxx_hal::subghz::SubGhz::steal() };
     /// # let mut delay = new_delay(cp.SYST, &dp.RCC);
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     subghz::{wakeup, SleepCfg, StandbyClk},
     ///     util::new_delay,
     /// };
@@ -789,7 +789,7 @@ where
     /// unsafe { sg.set_sleep(SleepCfg::default())? };
     /// delay.delay_us(500);
     /// unsafe { wakeup() };
-    /// # Ok::<(), stm32wl_hal::subghz::Error>(())
+    /// # Ok::<(), stm32wlxx_hal::subghz::Error>(())
     /// ```
     pub unsafe fn set_sleep(&mut self, cfg: SleepCfg) -> Result<(), Error> {
         self.write(&[OpCode::SetSleep as u8, u8::from(cfg)])

--- a/hal/src/subghz/mod_params.rs
+++ b/hal/src/subghz/mod_params.rs
@@ -52,7 +52,7 @@ impl FskBandwidth {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskBandwidth;
+    /// use stm32wlxx_hal::subghz::FskBandwidth;
     ///
     /// assert_eq!(FskBandwidth::Bw4.hertz(), 4_800);
     /// assert_eq!(FskBandwidth::Bw5.hertz(), 5_800);
@@ -109,7 +109,7 @@ impl FskBandwidth {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskBandwidth;
+    /// use stm32wlxx_hal::subghz::FskBandwidth;
     ///
     /// assert_eq!(FskBandwidth::from_bits(0x1F), Ok(FskBandwidth::Bw4));
     /// assert_eq!(FskBandwidth::from_bits(0x17), Ok(FskBandwidth::Bw5));
@@ -206,7 +206,7 @@ impl FskBitrate {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskBitrate;
+    /// use stm32wlxx_hal::subghz::FskBitrate;
     ///
     /// const BITRATE: FskBitrate = FskBitrate::from_bps(9600);
     /// assert_eq!(BITRATE.as_bps(), 9600);
@@ -235,7 +235,7 @@ impl FskBitrate {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskBitrate;
+    /// use stm32wlxx_hal::subghz::FskBitrate;
     ///
     /// const BITRATE: FskBitrate = FskBitrate::from_raw(0x7D00);
     /// assert_eq!(BITRATE.as_bps(), 32_000);
@@ -251,7 +251,7 @@ impl FskBitrate {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskBitrate;
+    /// use stm32wlxx_hal::subghz::FskBitrate;
     ///
     /// const BITS_PER_SEC: u32 = 9600;
     /// const BITRATE: FskBitrate = FskBitrate::from_bps(BITS_PER_SEC);
@@ -296,7 +296,7 @@ impl FskFdev {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskFdev;
+    /// use stm32wlxx_hal::subghz::FskFdev;
     ///
     /// const FDEV: FskFdev = FskFdev::from_hertz(31_250);
     /// assert_eq!(FDEV.as_hertz(), 31_250);
@@ -317,7 +317,7 @@ impl FskFdev {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskFdev;
+    /// use stm32wlxx_hal::subghz::FskFdev;
     ///
     /// const FDEV: FskFdev = FskFdev::from_raw(0x8000);
     /// assert_eq!(FDEV.as_hertz(), 31_250);
@@ -333,7 +333,7 @@ impl FskFdev {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskFdev;
+    /// use stm32wlxx_hal::subghz::FskFdev;
     ///
     /// const HERTZ: u32 = 31_250;
     /// const FDEV: FskFdev = FskFdev::from_hertz(HERTZ);
@@ -363,7 +363,7 @@ impl FskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::FskModParams;
+    /// use stm32wlxx_hal::subghz::FskModParams;
     ///
     /// const MOD_PARAMS: FskModParams = FskModParams::new();
     /// ```
@@ -394,7 +394,7 @@ impl FskModParams {
     /// Setting the bitrate to 32,000 bits per second.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskBitrate, FskModParams};
+    /// use stm32wlxx_hal::subghz::{FskBitrate, FskModParams};
     ///
     /// const BITRATE: FskBitrate = FskBitrate::from_bps(32_000);
     /// const MOD_PARAMS: FskModParams = FskModParams::new().set_bitrate(BITRATE);
@@ -412,7 +412,7 @@ impl FskModParams {
     /// Setting the bitrate to 32,000 bits per second.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskBitrate, FskModParams};
+    /// use stm32wlxx_hal::subghz::{FskBitrate, FskModParams};
     ///
     /// const BITRATE: FskBitrate = FskBitrate::from_bps(32_000);
     /// const MOD_PARAMS: FskModParams = FskModParams::new().set_bitrate(BITRATE);
@@ -434,7 +434,7 @@ impl FskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskModParams, FskPulseShape};
+    /// use stm32wlxx_hal::subghz::{FskModParams, FskPulseShape};
     ///
     /// const MOD_PARAMS: FskModParams = FskModParams::new().set_pulse_shape(FskPulseShape::Bt03);
     /// # assert_eq!(MOD_PARAMS.as_slice()[4], 0x08);
@@ -453,7 +453,7 @@ impl FskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskBandwidth, FskModParams};
+    /// use stm32wlxx_hal::subghz::{FskBandwidth, FskModParams};
     ///
     /// const MOD_PARAMS: FskModParams = FskModParams::new().set_bandwidth(FskBandwidth::Bw9);
     /// assert_eq!(MOD_PARAMS.bandwidth(), Ok(FskBandwidth::Bw9));
@@ -467,7 +467,7 @@ impl FskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskBandwidth, FskModParams};
+    /// use stm32wlxx_hal::subghz::{FskBandwidth, FskModParams};
     ///
     /// const MOD_PARAMS: FskModParams = FskModParams::new().set_bandwidth(FskBandwidth::Bw9);
     /// # assert_eq!(MOD_PARAMS.as_slice()[5], 0x1E);
@@ -483,7 +483,7 @@ impl FskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskFdev, FskModParams};
+    /// use stm32wlxx_hal::subghz::{FskFdev, FskModParams};
     ///
     /// const FDEV: FskFdev = FskFdev::from_hertz(31_250);
     /// const MOD_PARAMS: FskModParams = FskModParams::new().set_fdev(FDEV);
@@ -499,7 +499,7 @@ impl FskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskFdev, FskModParams};
+    /// use stm32wlxx_hal::subghz::{FskFdev, FskModParams};
     ///
     /// const FDEV: FskFdev = FskFdev::from_hertz(31_250);
     /// const MOD_PARAMS: FskModParams = FskModParams::new().set_fdev(FDEV);
@@ -536,7 +536,7 @@ impl FskModParams {
     ///
     /// ```
     /// extern crate static_assertions as sa;
-    /// use stm32wl_hal::subghz::{FskBandwidth, FskBitrate, FskFdev, FskModParams, FskPulseShape};
+    /// use stm32wlxx_hal::subghz::{FskBandwidth, FskBitrate, FskFdev, FskModParams, FskPulseShape};
     ///
     /// const MOD_PARAMS: FskModParams = FskModParams::new()
     ///     .set_bitrate(FskBitrate::from_bps(20_000))
@@ -576,7 +576,7 @@ impl FskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskBandwidth, FskBitrate, FskFdev, FskModParams, FskPulseShape};
+    /// use stm32wlxx_hal::subghz::{FskBandwidth, FskBitrate, FskFdev, FskModParams, FskPulseShape};
     ///
     /// const BITRATE: FskBitrate = FskBitrate::from_bps(20_000);
     /// const PULSE_SHAPE: FskPulseShape = FskPulseShape::Bt03;
@@ -671,7 +671,7 @@ impl LoRaBandwidth {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::LoRaBandwidth;
+    /// use stm32wlxx_hal::subghz::LoRaBandwidth;
     ///
     /// assert_eq!(LoRaBandwidth::Bw7.hertz(), 7_810);
     /// assert_eq!(LoRaBandwidth::Bw10.hertz(), 10_420);
@@ -747,7 +747,7 @@ impl LoRaModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::LoRaModParams;
+    /// use stm32wlxx_hal::subghz::LoRaModParams;
     ///
     /// const MOD_PARAMS: LoRaModParams = LoRaModParams::new();
     /// assert_eq!(MOD_PARAMS, LoRaModParams::default());
@@ -769,7 +769,7 @@ impl LoRaModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{LoRaModParams, SpreadingFactor};
+    /// use stm32wlxx_hal::subghz::{LoRaModParams, SpreadingFactor};
     ///
     /// const MOD_PARAMS: LoRaModParams = LoRaModParams::new().set_sf(SpreadingFactor::Sf7);
     /// # assert_eq!(MOD_PARAMS.as_slice(), &[0x8B, 0x07, 0x00, 0x00, 0x00]);
@@ -785,7 +785,7 @@ impl LoRaModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{LoRaBandwidth, LoRaModParams};
+    /// use stm32wlxx_hal::subghz::{LoRaBandwidth, LoRaModParams};
     ///
     /// const MOD_PARAMS: LoRaModParams = LoRaModParams::new().set_bw(LoRaBandwidth::Bw125);
     /// # assert_eq!(MOD_PARAMS.as_slice(), &[0x8B, 0x05, 0x04, 0x00, 0x00]);
@@ -801,7 +801,7 @@ impl LoRaModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CodingRate, LoRaModParams};
+    /// use stm32wlxx_hal::subghz::{CodingRate, LoRaModParams};
     ///
     /// const MOD_PARAMS: LoRaModParams = LoRaModParams::new().set_cr(CodingRate::Cr45);
     /// # assert_eq!(MOD_PARAMS.as_slice(), &[0x8B, 0x05, 0x00, 0x01, 0x00]);
@@ -817,7 +817,7 @@ impl LoRaModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::LoRaModParams;
+    /// use stm32wlxx_hal::subghz::LoRaModParams;
     ///
     /// const MOD_PARAMS: LoRaModParams = LoRaModParams::new().set_ldro_en(true);
     /// # assert_eq!(MOD_PARAMS.as_slice(), &[0x8B, 0x05, 0x00, 0x00, 0x01]);
@@ -833,7 +833,7 @@ impl LoRaModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CodingRate, LoRaBandwidth, LoRaModParams, SpreadingFactor};
+    /// use stm32wlxx_hal::subghz::{CodingRate, LoRaBandwidth, LoRaModParams, SpreadingFactor};
     ///
     /// const MOD_PARAMS: LoRaModParams = LoRaModParams::new()
     ///     .set_sf(SpreadingFactor::Sf7)
@@ -872,7 +872,7 @@ impl BpskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BpskModParams;
+    /// use stm32wlxx_hal::subghz::BpskModParams;
     ///
     /// const MOD_PARAMS: BpskModParams = BpskModParams::new();
     /// assert_eq!(MOD_PARAMS, BpskModParams::default());
@@ -891,7 +891,7 @@ impl BpskModParams {
     /// Setting the bitrate to 600 bits per second.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{BpskModParams, FskBitrate};
+    /// use stm32wlxx_hal::subghz::{BpskModParams, FskBitrate};
     ///
     /// const BITRATE: FskBitrate = FskBitrate::from_bps(600);
     /// const MOD_PARAMS: BpskModParams = BpskModParams::new().set_bitrate(BITRATE);
@@ -913,7 +913,7 @@ impl BpskModParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{BpskModParams, FskBitrate};
+    /// use stm32wlxx_hal::subghz::{BpskModParams, FskBitrate};
     ///
     /// const BITRATE: FskBitrate = FskBitrate::from_bps(100);
     /// const MOD_PARAMS: BpskModParams = BpskModParams::new().set_bitrate(BITRATE);

--- a/hal/src/subghz/op_error.rs
+++ b/hal/src/subghz/op_error.rs
@@ -31,7 +31,7 @@ impl OpError {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::OpError;
+    /// use stm32wlxx_hal::subghz::OpError;
     ///
     /// assert_eq!(OpError::PaRampError.mask(), 0b1_0000_0000);
     /// assert_eq!(OpError::PllLockError.mask(), 0b0_0100_0000);

--- a/hal/src/subghz/pa_config.rs
+++ b/hal/src/subghz/pa_config.rs
@@ -73,7 +73,7 @@ impl PaConfig {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PaConfig;
+    /// use stm32wlxx_hal::subghz::PaConfig;
     ///
     /// const PA_CONFIG: PaConfig = PaConfig::new();
     /// ```
@@ -99,7 +99,7 @@ impl PaConfig {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{PaConfig, PaSel};
+    /// use stm32wlxx_hal::subghz::{PaConfig, PaSel};
     ///
     /// const PA_CONFIG: PaConfig = PaConfig::new().set_pa(PaSel::Lp).set_pa_duty_cycle(0x4);
     /// # assert_eq!(PA_CONFIG.as_slice()[1], 0x04);
@@ -117,7 +117,7 @@ impl PaConfig {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{PaConfig, PaSel};
+    /// use stm32wlxx_hal::subghz::{PaConfig, PaSel};
     ///
     /// const PA_CONFIG: PaConfig = PaConfig::new().set_pa(PaSel::Hp).set_hp_max(0x2);
     /// # assert_eq!(PA_CONFIG.as_slice()[2], 0x02);
@@ -133,7 +133,7 @@ impl PaConfig {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{PaConfig, PaSel};
+    /// use stm32wlxx_hal::subghz::{PaConfig, PaSel};
     ///
     /// const PA_CONFIG_HP: PaConfig = PaConfig::new().set_pa(PaSel::Hp);
     /// const PA_CONFIG_LP: PaConfig = PaConfig::new().set_pa(PaSel::Lp);
@@ -151,7 +151,7 @@ impl PaConfig {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{PaConfig, PaSel};
+    /// use stm32wlxx_hal::subghz::{PaConfig, PaSel};
     ///
     /// const PA_CONFIG: PaConfig = PaConfig::new()
     ///     .set_pa(PaSel::Hp)

--- a/hal/src/subghz/packet_params.rs
+++ b/hal/src/subghz/packet_params.rs
@@ -91,7 +91,7 @@ impl GenericPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::GenericPacketParams;
+    /// use stm32wlxx_hal::subghz::GenericPacketParams;
     ///
     /// const PKT_PARAMS: GenericPacketParams = GenericPacketParams::new();
     /// assert_eq!(PKT_PARAMS, GenericPacketParams::default());
@@ -119,7 +119,7 @@ impl GenericPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::GenericPacketParams;
+    /// use stm32wlxx_hal::subghz::GenericPacketParams;
     ///
     /// const PKT_PARAMS: GenericPacketParams = GenericPacketParams::new().set_preamble_len(0x1234);
     /// # assert_eq!(PKT_PARAMS.as_slice()[1], 0x12);
@@ -140,7 +140,7 @@ impl GenericPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{GenericPacketParams, PreambleDetection};
+    /// use stm32wlxx_hal::subghz::{GenericPacketParams, PreambleDetection};
     ///
     /// const PKT_PARAMS: GenericPacketParams =
     ///     GenericPacketParams::new().set_preamble_detection(PreambleDetection::Bit8);
@@ -165,7 +165,7 @@ impl GenericPacketParams {
     /// Set the sync word length to 4 bytes (16 bits).
     ///
     /// ```
-    /// use stm32wl_hal::subghz::GenericPacketParams;
+    /// use stm32wlxx_hal::subghz::GenericPacketParams;
     ///
     /// const PKT_PARAMS: GenericPacketParams = GenericPacketParams::new().set_sync_word_len(16);
     /// # assert_eq!(PKT_PARAMS.as_slice()[4], 0x10);
@@ -188,7 +188,7 @@ impl GenericPacketParams {
     /// Enable address on the node address.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{AddrComp, GenericPacketParams};
+    /// use stm32wlxx_hal::subghz::{AddrComp, GenericPacketParams};
     ///
     /// const PKT_PARAMS: GenericPacketParams =
     ///     GenericPacketParams::new().set_addr_comp(AddrComp::Node);
@@ -211,7 +211,7 @@ impl GenericPacketParams {
     /// Set the header type to a variable length.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{GenericPacketParams, HeaderType};
+    /// use stm32wlxx_hal::subghz::{GenericPacketParams, HeaderType};
     ///
     /// const PKT_PARAMS: GenericPacketParams =
     ///     GenericPacketParams::new().set_header_type(HeaderType::Variable);
@@ -228,7 +228,7 @@ impl GenericPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::GenericPacketParams;
+    /// use stm32wlxx_hal::subghz::GenericPacketParams;
     ///
     /// const PKT_PARAMS: GenericPacketParams = GenericPacketParams::new().set_payload_len(12);
     /// # assert_eq!(PKT_PARAMS.as_slice()[7], 12);
@@ -244,7 +244,7 @@ impl GenericPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CrcType, GenericPacketParams};
+    /// use stm32wlxx_hal::subghz::{CrcType, GenericPacketParams};
     ///
     /// const PKT_PARAMS: GenericPacketParams =
     ///     GenericPacketParams::new().set_crc_type(CrcType::Byte2Inverted);
@@ -263,7 +263,7 @@ impl GenericPacketParams {
     /// Enable whitening.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::GenericPacketParams;
+    /// use stm32wlxx_hal::subghz::GenericPacketParams;
     ///
     /// const PKT_PARAMS: GenericPacketParams = GenericPacketParams::new().set_whitening_enable(true);
     /// # assert_eq!(PKT_PARAMS.as_slice()[9], 1);
@@ -279,7 +279,7 @@ impl GenericPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{
+    /// use stm32wlxx_hal::subghz::{
     ///     AddrComp, CrcType, GenericPacketParams, HeaderType, PreambleDetection,
     /// };
     ///
@@ -325,7 +325,7 @@ impl LoRaPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::LoRaPacketParams;
+    /// use stm32wlxx_hal::subghz::LoRaPacketParams;
     ///
     /// const PKT_PARAMS: LoRaPacketParams = LoRaPacketParams::new();
     /// assert_eq!(PKT_PARAMS, LoRaPacketParams::default());
@@ -352,7 +352,7 @@ impl LoRaPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::LoRaPacketParams;
+    /// use stm32wlxx_hal::subghz::LoRaPacketParams;
     ///
     /// const PKT_PARAMS: LoRaPacketParams = LoRaPacketParams::new().set_preamble_len(0x1234);
     /// # assert_eq!(PKT_PARAMS.as_slice()[1], 0x12);
@@ -375,7 +375,7 @@ impl LoRaPacketParams {
     /// Set the payload type to a fixed length.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{HeaderType, LoRaPacketParams};
+    /// use stm32wlxx_hal::subghz::{HeaderType, LoRaPacketParams};
     ///
     /// const PKT_PARAMS: LoRaPacketParams = LoRaPacketParams::new().set_header_type(HeaderType::Fixed);
     /// # assert_eq!(PKT_PARAMS.as_slice()[3], 0x01);
@@ -391,7 +391,7 @@ impl LoRaPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::LoRaPacketParams;
+    /// use stm32wlxx_hal::subghz::LoRaPacketParams;
     ///
     /// const PKT_PARAMS: LoRaPacketParams = LoRaPacketParams::new().set_payload_len(12);
     /// # assert_eq!(PKT_PARAMS.as_slice()[4], 12);
@@ -409,7 +409,7 @@ impl LoRaPacketParams {
     /// Enable CRC.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::LoRaPacketParams;
+    /// use stm32wlxx_hal::subghz::LoRaPacketParams;
     ///
     /// const PKT_PARAMS: LoRaPacketParams = LoRaPacketParams::new().set_crc_en(true);
     /// # assert_eq!(PKT_PARAMS.as_slice()[5], 0x1);
@@ -427,7 +427,7 @@ impl LoRaPacketParams {
     /// Use an inverted IQ setup.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::LoRaPacketParams;
+    /// use stm32wlxx_hal::subghz::LoRaPacketParams;
     ///
     /// const PKT_PARAMS: LoRaPacketParams = LoRaPacketParams::new().set_invert_iq(true);
     /// # assert_eq!(PKT_PARAMS.as_slice()[6], 0x1);
@@ -443,7 +443,7 @@ impl LoRaPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{HeaderType, LoRaPacketParams};
+    /// use stm32wlxx_hal::subghz::{HeaderType, LoRaPacketParams};
     ///
     /// const PKT_PARAMS: LoRaPacketParams = LoRaPacketParams::new()
     ///     .set_preamble_len(5 * 8)
@@ -485,7 +485,7 @@ impl BpskPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BpskPacketParams;
+    /// use stm32wlxx_hal::subghz::BpskPacketParams;
     ///
     /// const PKT_PARAMS: BpskPacketParams = BpskPacketParams::new();
     /// assert_eq!(PKT_PARAMS, BpskPacketParams::default());
@@ -503,7 +503,7 @@ impl BpskPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::BpskPacketParams;
+    /// use stm32wlxx_hal::subghz::BpskPacketParams;
     ///
     /// const PKT_PARAMS: BpskPacketParams = BpskPacketParams::new().set_payload_len(12);
     /// # assert_eq!(PKT_PARAMS.as_slice()[1], 12);
@@ -519,7 +519,7 @@ impl BpskPacketParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{BpskPacketParams, HeaderType};
+    /// use stm32wlxx_hal::subghz::{BpskPacketParams, HeaderType};
     ///
     /// const PKT_PARAMS: BpskPacketParams = BpskPacketParams::new().set_payload_len(24);
     ///

--- a/hal/src/subghz/packet_status.rs
+++ b/hal/src/subghz/packet_status.rs
@@ -24,7 +24,7 @@ impl FskPacketStatus {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CmdStatus, FskPacketStatus, Status, StatusMode};
+    /// use stm32wlxx_hal::subghz::{CmdStatus, FskPacketStatus, Status, StatusMode};
     ///
     /// let example_data_from_radio: [u8; 4] = [0x54, 0, 0, 0];
     /// let pkt_status: FskPacketStatus = FskPacketStatus::from(example_data_from_radio);
@@ -88,7 +88,7 @@ impl FskPacketStatus {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::{subghz::FskPacketStatus, Ratio};
+    /// use stm32wlxx_hal::{subghz::FskPacketStatus, Ratio};
     ///
     /// let example_data_from_radio: [u8; 4] = [0, 0, 80, 0];
     /// let pkt_status: FskPacketStatus = FskPacketStatus::from(example_data_from_radio);
@@ -105,7 +105,7 @@ impl FskPacketStatus {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::{subghz::FskPacketStatus, Ratio};
+    /// use stm32wlxx_hal::{subghz::FskPacketStatus, Ratio};
     ///
     /// let example_data_from_radio: [u8; 4] = [0, 0, 0, 100];
     /// let pkt_status: FskPacketStatus = FskPacketStatus::from(example_data_from_radio);
@@ -189,7 +189,7 @@ impl LoRaPacketStatus {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CmdStatus, LoRaPacketStatus, Status, StatusMode};
+    /// use stm32wlxx_hal::subghz::{CmdStatus, LoRaPacketStatus, Status, StatusMode};
     ///
     /// let example_data_from_radio: [u8; 4] = [0x54, 0, 0, 0];
     /// let pkt_status: LoRaPacketStatus = LoRaPacketStatus::from(example_data_from_radio);
@@ -208,7 +208,7 @@ impl LoRaPacketStatus {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::{subghz::LoRaPacketStatus, Ratio};
+    /// use stm32wlxx_hal::{subghz::LoRaPacketStatus, Ratio};
     ///
     /// let example_data_from_radio: [u8; 4] = [0, 80, 0, 0];
     /// let pkt_status: LoRaPacketStatus = LoRaPacketStatus::from(example_data_from_radio);
@@ -225,7 +225,7 @@ impl LoRaPacketStatus {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::{subghz::LoRaPacketStatus, Ratio};
+    /// use stm32wlxx_hal::{subghz::LoRaPacketStatus, Ratio};
     ///
     /// let example_data_from_radio: [u8; 4] = [0, 0, 40, 0];
     /// let pkt_status: LoRaPacketStatus = LoRaPacketStatus::from(example_data_from_radio);
@@ -242,7 +242,7 @@ impl LoRaPacketStatus {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::{subghz::LoRaPacketStatus, Ratio};
+    /// use stm32wlxx_hal::{subghz::LoRaPacketStatus, Ratio};
     ///
     /// let example_data_from_radio: [u8; 4] = [0, 0, 0, 80];
     /// let pkt_status: LoRaPacketStatus = LoRaPacketStatus::from(example_data_from_radio);

--- a/hal/src/subghz/packet_type.rs
+++ b/hal/src/subghz/packet_type.rs
@@ -23,7 +23,7 @@ impl PacketType {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PacketType;
+    /// use stm32wlxx_hal::subghz::PacketType;
     ///
     /// assert_eq!(PacketType::from_raw(0), Ok(PacketType::Fsk));
     /// assert_eq!(PacketType::from_raw(1), Ok(PacketType::LoRa));

--- a/hal/src/subghz/pkt_ctrl.rs
+++ b/hal/src/subghz/pkt_ctrl.rs
@@ -50,7 +50,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PktCtrl;
+    /// use stm32wlxx_hal::subghz::PktCtrl;
     ///
     /// const PKT_CTRL: PktCtrl = PktCtrl::RESET.set_sync_det_en(true);
     /// ```
@@ -70,7 +70,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PktCtrl;
+    /// use stm32wlxx_hal::subghz::PktCtrl;
     ///
     /// let pc: PktCtrl = PktCtrl::RESET;
     /// assert_eq!(pc.sync_det_en(), true);
@@ -88,7 +88,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PktCtrl;
+    /// use stm32wlxx_hal::subghz::PktCtrl;
     ///
     /// const PKT_CTRL: PktCtrl = PktCtrl::RESET.set_cont_tx_en(true);
     /// ```
@@ -107,7 +107,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PktCtrl;
+    /// use stm32wlxx_hal::subghz::PktCtrl;
     ///
     /// let pc: PktCtrl = PktCtrl::RESET;
     /// assert_eq!(pc.cont_tx_en(), false);
@@ -133,7 +133,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{InfSeqSel, PktCtrl};
+    /// use stm32wlxx_hal::subghz::{InfSeqSel, PktCtrl};
     ///
     /// let pc: PktCtrl = PktCtrl::RESET;
     /// assert_eq!(pc.inf_seq_sel(), InfSeqSel::Five);
@@ -164,7 +164,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PktCtrl;
+    /// use stm32wlxx_hal::subghz::PktCtrl;
     ///
     /// const PKT_CTRL: PktCtrl = PktCtrl::RESET.set_inf_seq_en(true);
     /// ```
@@ -183,7 +183,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PktCtrl;
+    /// use stm32wlxx_hal::subghz::PktCtrl;
     ///
     /// let pc: PktCtrl = PktCtrl::RESET;
     /// assert_eq!(pc.inf_seq_en(), false);
@@ -201,7 +201,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PktCtrl;
+    /// use stm32wlxx_hal::subghz::PktCtrl;
     ///
     /// const PKT_CTRL: PktCtrl = PktCtrl::RESET.set_whitening_init(true);
     /// ```
@@ -220,7 +220,7 @@ impl PktCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PktCtrl;
+    /// use stm32wlxx_hal::subghz::PktCtrl;
     ///
     /// let pc: PktCtrl = PktCtrl::RESET;
     /// assert_eq!(pc.whitening_init(), true);

--- a/hal/src/subghz/pwr_ctrl.rs
+++ b/hal/src/subghz/pwr_ctrl.rs
@@ -21,7 +21,7 @@ impl CurrentLim {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::CurrentLim;
+    /// use stm32wlxx_hal::subghz::CurrentLim;
     ///
     /// assert_eq!(CurrentLim::Milli25.as_milliamps(), 25);
     /// assert_eq!(CurrentLim::Milli50.as_milliamps(), 50);
@@ -74,7 +74,7 @@ impl PwrCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PwrCtrl;
+    /// use stm32wlxx_hal::subghz::PwrCtrl;
     ///
     /// const PWR_CTRL: PwrCtrl = PwrCtrl::RESET.set_current_lim_en(true);
     /// # assert_eq!(u8::from(PWR_CTRL), 0x50u8);
@@ -94,7 +94,7 @@ impl PwrCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::PwrCtrl;
+    /// use stm32wlxx_hal::subghz::PwrCtrl;
     ///
     /// let pc: PwrCtrl = PwrCtrl::RESET;
     /// assert_eq!(pc.current_limit_en(), true);
@@ -120,7 +120,7 @@ impl PwrCtrl {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CurrentLim, PwrCtrl};
+    /// use stm32wlxx_hal::subghz::{CurrentLim, PwrCtrl};
     ///
     /// let pc: PwrCtrl = PwrCtrl::RESET;
     /// assert_eq!(pc.current_lim(), CurrentLim::Milli50);

--- a/hal/src/subghz/rf_frequency.rs
+++ b/hal/src/subghz/rf_frequency.rs
@@ -15,7 +15,7 @@ impl RfFreq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::RfFreq;
+    /// use stm32wlxx_hal::subghz::RfFreq;
     ///
     /// assert_eq!(RfFreq::F915.freq(), 915_000_000);
     /// ```
@@ -26,7 +26,7 @@ impl RfFreq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::RfFreq;
+    /// use stm32wlxx_hal::subghz::RfFreq;
     ///
     /// assert_eq!(RfFreq::F868.freq(), 868_000_000);
     /// ```
@@ -37,7 +37,7 @@ impl RfFreq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::RfFreq;
+    /// use stm32wlxx_hal::subghz::RfFreq;
     ///
     /// assert_eq!(RfFreq::F433.freq(), 433_000_000);
     /// ```
@@ -52,7 +52,7 @@ impl RfFreq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::RfFreq;
+    /// use stm32wlxx_hal::subghz::RfFreq;
     ///
     /// const FREQ: RfFreq = RfFreq::from_raw(0x39300000);
     /// assert_eq!(FREQ, RfFreq::F915);
@@ -78,7 +78,7 @@ impl RfFreq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::RfFreq;
+    /// use stm32wlxx_hal::subghz::RfFreq;
     ///
     /// const FREQ: RfFreq = RfFreq::from_frequency(915_000_000);
     /// assert_eq!(FREQ, RfFreq::F915);
@@ -100,7 +100,7 @@ impl RfFreq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::RfFreq;
+    /// use stm32wlxx_hal::subghz::RfFreq;
     ///
     /// assert_eq!(RfFreq::from_raw(0x39300000).freq(), 915_000_000);
     /// ```
@@ -113,7 +113,7 @@ impl RfFreq {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::RfFreq;
+    /// use stm32wlxx_hal::subghz::RfFreq;
     ///
     /// assert_eq!(RfFreq::F915.as_slice(), &[0x86, 0x39, 0x30, 0x00, 0x00]);
     /// ```

--- a/hal/src/subghz/sleep_cfg.rs
+++ b/hal/src/subghz/sleep_cfg.rs
@@ -42,7 +42,7 @@ impl SleepCfg {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::SleepCfg;
+    /// use stm32wlxx_hal::subghz::SleepCfg;
     ///
     /// const SLEEP_CFG: SleepCfg = SleepCfg::new();
     /// assert_eq!(SLEEP_CFG, SleepCfg::default());
@@ -59,7 +59,7 @@ impl SleepCfg {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{SleepCfg, Startup};
+    /// use stm32wlxx_hal::subghz::{SleepCfg, Startup};
     ///
     /// const SLEEP_CFG: SleepCfg = SleepCfg::new().set_startup(Startup::Cold);
     /// # assert_eq!(u8::from(SLEEP_CFG), 0b001);
@@ -79,7 +79,7 @@ impl SleepCfg {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::SleepCfg;
+    /// use stm32wlxx_hal::subghz::SleepCfg;
     ///
     /// const SLEEP_CFG: SleepCfg = SleepCfg::new().set_rtc_wakeup_en(false);
     /// # assert_eq!(u8::from(SLEEP_CFG), 0b100);

--- a/hal/src/subghz/smps.rs
+++ b/hal/src/subghz/smps.rs
@@ -21,7 +21,7 @@ impl SmpsDrv {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::SmpsDrv;
+    /// use stm32wlxx_hal::subghz::SmpsDrv;
     ///
     /// assert_eq!(SmpsDrv::Milli20.as_milliamps(), 20);
     /// assert_eq!(SmpsDrv::Milli40.as_milliamps(), 40);

--- a/hal/src/subghz/stats.rs
+++ b/hal/src/subghz/stats.rs
@@ -35,7 +35,7 @@ impl<ModType> Stats<ModType> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CmdStatus, FskStats, Stats, StatusMode};
+    /// use stm32wlxx_hal::subghz::{CmdStatus, FskStats, Stats, StatusMode};
     ///
     /// let example_data_from_radio: [u8; 7] = [0x54, 0, 0, 0, 0, 0, 0];
     /// let stats: Stats<FskStats> = Stats::from_raw_fsk(example_data_from_radio);
@@ -51,7 +51,7 @@ impl<ModType> Stats<ModType> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskStats, Stats};
+    /// use stm32wlxx_hal::subghz::{FskStats, Stats};
     ///
     /// let example_data_from_radio: [u8; 7] = [0x54, 0, 3, 0, 0, 0, 0];
     /// let stats: Stats<FskStats> = Stats::from_raw_fsk(example_data_from_radio);
@@ -66,7 +66,7 @@ impl<ModType> Stats<ModType> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{LoRaStats, Stats};
+    /// use stm32wlxx_hal::subghz::{LoRaStats, Stats};
     ///
     /// let example_data_from_radio: [u8; 7] = [0x54, 0, 0, 0, 1, 0, 0];
     /// let stats: Stats<LoRaStats> = Stats::from_raw_lora(example_data_from_radio);
@@ -83,7 +83,7 @@ impl Stats<FskStats> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskStats, Stats};
+    /// use stm32wlxx_hal::subghz::{FskStats, Stats};
     ///
     /// let example_data_from_radio: [u8; 7] = [0x54, 0, 0, 0, 0, 0, 0];
     /// let stats: Stats<FskStats> = Stats::from_raw_fsk(example_data_from_radio);
@@ -97,7 +97,7 @@ impl Stats<FskStats> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{FskStats, Stats};
+    /// use stm32wlxx_hal::subghz::{FskStats, Stats};
     ///
     /// let example_data_from_radio: [u8; 7] = [0x54, 0, 0, 0, 0, 0, 1];
     /// let stats: Stats<FskStats> = Stats::from_raw_fsk(example_data_from_radio);
@@ -114,7 +114,7 @@ impl Stats<LoRaStats> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{LoRaStats, Stats};
+    /// use stm32wlxx_hal::subghz::{LoRaStats, Stats};
     ///
     /// let example_data_from_radio: [u8; 7] = [0x54, 0, 0, 0, 0, 0, 0];
     /// let stats: Stats<LoRaStats> = Stats::from_raw_lora(example_data_from_radio);
@@ -128,7 +128,7 @@ impl Stats<LoRaStats> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{LoRaStats, Stats};
+    /// use stm32wlxx_hal::subghz::{LoRaStats, Stats};
     ///
     /// let example_data_from_radio: [u8; 7] = [0x54, 0, 0, 0, 0, 0, 1];
     /// let stats: Stats<LoRaStats> = Stats::from_raw_lora(example_data_from_radio);

--- a/hal/src/subghz/status.rs
+++ b/hal/src/subghz/status.rs
@@ -26,7 +26,7 @@ impl StatusMode {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::StatusMode;
+    /// use stm32wlxx_hal::subghz::StatusMode;
     ///
     /// assert_eq!(StatusMode::from_raw(0x2), Ok(StatusMode::StandbyRc));
     /// assert_eq!(StatusMode::from_raw(0x3), Ok(StatusMode::StandbyHse));
@@ -89,7 +89,7 @@ impl CmdStatus {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::CmdStatus;
+    /// use stm32wlxx_hal::subghz::CmdStatus;
     ///
     /// assert_eq!(CmdStatus::from_raw(0x2), Ok(CmdStatus::Avaliable));
     /// assert_eq!(CmdStatus::from_raw(0x3), Ok(CmdStatus::Timeout));
@@ -138,7 +138,7 @@ impl Status {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CmdStatus, Status, StatusMode};
+    /// use stm32wlxx_hal::subghz::{CmdStatus, Status, StatusMode};
     ///
     /// const STATUS: Status = Status::from_raw(0x54_u8);
     /// assert_eq!(STATUS.mode(), Ok(StatusMode::Rx));
@@ -153,7 +153,7 @@ impl Status {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{Status, StatusMode};
+    /// use stm32wlxx_hal::subghz::{Status, StatusMode};
     ///
     /// let status: Status = 0xACu8.into();
     /// assert_eq!(status.mode(), Ok(StatusMode::StandbyRc));
@@ -170,7 +170,7 @@ impl Status {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{CmdStatus, Status};
+    /// use stm32wlxx_hal::subghz::{CmdStatus, Status};
     ///
     /// let status: Status = 0xACu8.into();
     /// assert_eq!(status.cmd(), Ok(CmdStatus::Complete));

--- a/hal/src/subghz/tcxo_mode.rs
+++ b/hal/src/subghz/tcxo_mode.rs
@@ -49,7 +49,7 @@ impl TcxoTrim {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::TcxoTrim;
+    /// use stm32wlxx_hal::subghz::TcxoTrim;
     ///
     /// assert_eq!(TcxoTrim::Volts1pt6.as_millivolts(), 1600);
     /// assert_eq!(TcxoTrim::Volts1pt7.as_millivolts(), 1700);
@@ -93,7 +93,7 @@ impl TcxoMode {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::TcxoMode;
+    /// use stm32wlxx_hal::subghz::TcxoMode;
     ///
     /// const TCXO_MODE: TcxoMode = TcxoMode::new();
     /// ```
@@ -111,7 +111,7 @@ impl TcxoMode {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{TcxoMode, TcxoTrim};
+    /// use stm32wlxx_hal::subghz::{TcxoMode, TcxoTrim};
     ///
     /// const TCXO_MODE: TcxoMode = TcxoMode::new().set_txco_trim(TcxoTrim::Volts1pt6);
     /// # assert_eq!(TCXO_MODE.as_slice()[1], 0x00);
@@ -128,7 +128,7 @@ impl TcxoMode {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::{TcxoMode, Timeout};
+    /// use stm32wlxx_hal::subghz::{TcxoMode, Timeout};
     ///
     /// // 15.625 ms timeout
     /// const TIMEOUT: Timeout = Timeout::from_duration_sat(Duration::from_millis(15_625));
@@ -151,7 +151,7 @@ impl TcxoMode {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{TcxoMode, TcxoTrim, Timeout};
+    /// use stm32wlxx_hal::subghz::{TcxoMode, TcxoTrim, Timeout};
     ///
     /// const TCXO_MODE: TcxoMode = TcxoMode::new()
     ///     .set_txco_trim(TcxoTrim::Volts1pt7)

--- a/hal/src/subghz/timeout.rs
+++ b/hal/src/subghz/timeout.rs
@@ -39,7 +39,7 @@ impl Timeout {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// const TIMEOUT: Timeout = Timeout::DISABLED;
     /// assert_eq!(TIMEOUT.as_duration(), Duration::from_secs(0));
@@ -52,7 +52,7 @@ impl Timeout {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// const TIMEOUT: Timeout = Timeout::MIN;
     /// assert_eq!(TIMEOUT.into_bits(), 1);
@@ -65,7 +65,7 @@ impl Timeout {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// const TIMEOUT: Timeout = Timeout::MAX;
     /// assert_eq!(TIMEOUT.as_duration(), Duration::from_nanos(262_143_984_375));
@@ -80,7 +80,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(
     ///     Timeout::RESOLUTION.as_nanos(),
@@ -105,7 +105,7 @@ impl Timeout {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::{Timeout, ValueError};
+    /// use stm32wlxx_hal::subghz::{Timeout, ValueError};
     ///
     /// const MIN: Duration = Timeout::RESOLUTION;
     /// assert_eq!(Timeout::from_duration(MIN).unwrap(), Timeout::MIN);
@@ -115,7 +115,7 @@ impl Timeout {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::{Timeout, ValueError};
+    /// use stm32wlxx_hal::subghz::{Timeout, ValueError};
     ///
     /// const LOWER_LIMIT_NANOS: u128 = 7813;
     /// const TOO_LOW_NANOS: u128 = LOWER_LIMIT_NANOS - 1;
@@ -130,7 +130,7 @@ impl Timeout {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::{Timeout, ValueError};
+    /// use stm32wlxx_hal::subghz::{Timeout, ValueError};
     ///
     /// const UPPER_LIMIT_NANOS: u128 = Timeout::MAX.as_nanos() as u128 + 7812;
     /// const TOO_HIGH_NANOS: u128 = UPPER_LIMIT_NANOS + 1;
@@ -187,7 +187,7 @@ impl Timeout {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// const DURATION_MAX_NS: u64 = 262_143_984_376;
     ///
@@ -246,7 +246,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(Timeout::from_millis_sat(0), Timeout::MIN);
     /// assert_eq!(Timeout::from_millis_sat(262_144), Timeout::MAX);
@@ -271,7 +271,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(Timeout::from_raw(u32::MAX), Timeout::MAX);
     /// assert_eq!(Timeout::from_raw(0x00_FF_FF_FF), Timeout::MAX);
@@ -289,7 +289,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(Timeout::MAX.as_nanos(), 262_143_984_375);
     /// assert_eq!(Timeout::DISABLED.as_nanos(), 0);
@@ -305,7 +305,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(Timeout::MAX.as_micros(), 262_143_984);
     /// assert_eq!(Timeout::DISABLED.as_micros(), 0);
@@ -321,7 +321,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(Timeout::MAX.as_millis(), 262_143);
     /// assert_eq!(Timeout::DISABLED.as_millis(), 0);
@@ -337,7 +337,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(Timeout::MAX.as_secs(), 262);
     /// assert_eq!(Timeout::DISABLED.as_secs(), 0);
@@ -354,7 +354,7 @@ impl Timeout {
     ///
     /// ```
     /// use core::time::Duration;
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(
     ///     Timeout::MAX.as_duration(),
@@ -372,7 +372,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(Timeout::from_raw(u32::MAX).into_bits(), 0x00FF_FFFF);
     /// assert_eq!(Timeout::from_raw(1).into_bits(), 1);
@@ -386,7 +386,7 @@ impl Timeout {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::Timeout;
+    /// use stm32wlxx_hal::subghz::Timeout;
     ///
     /// assert_eq!(Timeout::from_raw(u32::MAX).as_bytes(), [0xFF, 0xFF, 0xFF]);
     /// assert_eq!(Timeout::from_raw(1).as_bytes(), [0, 0, 1]);

--- a/hal/src/subghz/tx_params.rs
+++ b/hal/src/subghz/tx_params.rs
@@ -100,7 +100,7 @@ impl TxParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::TxParams;
+    /// use stm32wlxx_hal::subghz::TxParams;
     ///
     /// const TX_PARAMS: TxParams = TxParams::new();
     /// assert_eq!(TX_PARAMS, TxParams::default());
@@ -136,7 +136,7 @@ impl TxParams {
     /// Set the output power to 0 dB.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{RampTime, TxParams};
+    /// use stm32wlxx_hal::subghz::{RampTime, TxParams};
     ///
     /// const TX_PARAMS: TxParams = TxParams::new().set_power(0x00);
     /// # assert_eq!(TX_PARAMS.as_slice()[1], 0x00);
@@ -156,7 +156,7 @@ impl TxParams {
     /// Set the ramp time to 200 microseconds.
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{RampTime, TxParams};
+    /// use stm32wlxx_hal::subghz::{RampTime, TxParams};
     ///
     /// const TX_PARAMS: TxParams = TxParams::new().set_ramp_time(RampTime::Micros200);
     /// # assert_eq!(TX_PARAMS.as_slice()[2], 0x04);
@@ -172,7 +172,7 @@ impl TxParams {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::{RampTime, TxParams};
+    /// use stm32wlxx_hal::subghz::{RampTime, TxParams};
     ///
     /// const TX_PARAMS: TxParams = TxParams::new()
     ///     .set_ramp_time(RampTime::Micros80)

--- a/hal/src/subghz/value_error.rs
+++ b/hal/src/subghz/value_error.rs
@@ -20,7 +20,7 @@ impl<T> ValueError<T> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::ValueError;
+    /// use stm32wlxx_hal::subghz::ValueError;
     ///
     /// const ERROR: ValueError<u8> = ValueError::too_high(101u8, 100u8);
     /// assert!(ERROR.over());
@@ -42,7 +42,7 @@ impl<T> ValueError<T> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::ValueError;
+    /// use stm32wlxx_hal::subghz::ValueError;
     ///
     /// const ERROR: ValueError<u8> = ValueError::too_low(200u8, 201u8);
     /// assert!(ERROR.under());
@@ -61,7 +61,7 @@ impl<T> ValueError<T> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::ValueError;
+    /// use stm32wlxx_hal::subghz::ValueError;
     ///
     /// const ERROR: ValueError<u8> = ValueError::too_high(101u8, 100u8);
     /// assert_eq!(ERROR.value(), &101u8);
@@ -75,7 +75,7 @@ impl<T> ValueError<T> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::ValueError;
+    /// use stm32wlxx_hal::subghz::ValueError;
     ///
     /// const ERROR: ValueError<u8> = ValueError::too_high(101u8, 100u8);
     /// assert_eq!(ERROR.limit(), &100u8);
@@ -89,7 +89,7 @@ impl<T> ValueError<T> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::ValueError;
+    /// use stm32wlxx_hal::subghz::ValueError;
     ///
     /// const ERROR: ValueError<u8> = ValueError::too_high(101u8, 100u8);
     /// assert!(ERROR.over());
@@ -104,7 +104,7 @@ impl<T> ValueError<T> {
     /// # Example
     ///
     /// ```
-    /// use stm32wl_hal::subghz::ValueError;
+    /// use stm32wlxx_hal::subghz::ValueError;
     ///
     /// const ERROR: ValueError<u8> = ValueError::too_low(200u8, 201u8);
     /// assert!(ERROR.under());

--- a/hal/src/uart.rs
+++ b/hal/src/uart.rs
@@ -84,7 +84,7 @@ impl LpUart<NoRx, NoTx> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     uart::{self, LpUart, NoRx, NoTx},
     /// };
@@ -130,7 +130,7 @@ impl Uart1<NoRx, NoTx> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     uart::{self, NoRx, NoTx, Uart1},
     /// };
@@ -174,7 +174,7 @@ impl Uart2<NoRx, NoTx> {
     /// # Example
     ///
     /// ```no_run
-    /// use stm32wl_hal::{
+    /// use stm32wlxx_hal::{
     ///     pac,
     ///     uart::{self, NoRx, NoTx, Uart2},
     /// };
@@ -313,7 +313,7 @@ macro_rules! impl_clock_en_dis {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{pac, uart::LpUart};
+            /// use stm32wlxx_hal::{pac, uart::LpUart};
             ///
             /// let mut dp: pac::Peripherals = pac::Peripherals::take().unwrap();
             /// LpUart::enable_clock(&mut dp.RCC);
@@ -360,7 +360,7 @@ macro_rules! impl_free_steal {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{
+            /// use stm32wlxx_hal::{
             ///     pac,
             ///     uart::{LpUart, NoRx, NoTx},
             /// };
@@ -395,7 +395,7 @@ macro_rules! impl_free_steal {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{
+            /// use stm32wlxx_hal::{
             ///     pac,
             ///     uart::{self, LpUart, NoRx, NoTx},
             /// };
@@ -427,7 +427,7 @@ macro_rules! impl_tx_en_dis {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{
+            /// use stm32wlxx_hal::{
             ///     cortex_m,
             ///     gpio::{pins, PortB},
             ///     pac,
@@ -467,7 +467,7 @@ macro_rules! impl_tx_en_dis {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{
+            /// use stm32wlxx_hal::{
             ///     cortex_m,
             ///     dma::{AllDma, Dma2Ch7},
             ///     gpio::{pins, PortB},
@@ -517,7 +517,7 @@ macro_rules! impl_tx_en_dis {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{
+            /// use stm32wlxx_hal::{
             ///     cortex_m,
             ///     gpio::{pins, PortB},
             ///     pac,
@@ -566,7 +566,7 @@ macro_rules! impl_rx_en_dis {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{
+            /// use stm32wlxx_hal::{
             ///     cortex_m,
             ///     gpio::{pins, PortB},
             ///     pac,
@@ -606,7 +606,7 @@ macro_rules! impl_rx_en_dis {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{
+            /// use stm32wlxx_hal::{
             ///     dma::{AllDma, Dma2Ch2},
             ///     gpio::{pins, PortB},
             ///     pac,
@@ -655,7 +655,7 @@ macro_rules! impl_rx_en_dis {
             /// # Example
             ///
             /// ```no_run
-            /// use stm32wl_hal::{
+            /// use stm32wlxx_hal::{
             ///     gpio::{pins, PortB},
             ///     pac,
             ///     uart::{self, LpUart, NoRx, NoTx},

--- a/hal/src/util.rs
+++ b/hal/src/util.rs
@@ -9,7 +9,7 @@ use cortex_m::{delay::Delay, peripheral::syst::SystClkSource};
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, util::new_delay};
+/// use stm32wlxx_hal::{pac, util::new_delay};
 ///
 /// let dp = pac::Peripherals::take().unwrap();
 /// let cp = pac::CorePeripherals::take().unwrap();
@@ -31,7 +31,7 @@ pub fn new_delay(syst: pac::SYST, rcc: &pac::RCC) -> Delay {
 /// # Example
 ///
 /// ```no_run
-/// use stm32wl_hal::{pac, util::reset_cycle_count};
+/// use stm32wlxx_hal::{pac, util::reset_cycle_count};
 ///
 /// let mut cp = pac::CorePeripherals::take().unwrap();
 /// cp.DCB.enable_trace();

--- a/lora-e5-bsp/Cargo.toml
+++ b/lora-e5-bsp/Cargo.toml
@@ -9,20 +9,20 @@ edition = "2021"
 license = "MIT"
 keywords = ["arm", "cortex-m", "stm32", "bsp", "seeed"]
 categories = ["embedded", "hardware-support", "no-std"]
-repository = "https://github.com/newAM/stm32wl-hal"
+repository = "https://github.com/newAM/stm32wlxx-hal"
 
 [features]
-defmt = ["stm32wl-hal/defmt"]
-rt = ["stm32wl-hal/rt"]
+defmt = ["stm32wlxx-hal/defmt"]
+rt = ["stm32wlxx-hal/rt"]
 
 # do NOT modify these features
-defmt-default = ["stm32wl-hal/defmt-default"]
-defmt-trace = ["stm32wl-hal/defmt-trace"]
-defmt-debug = ["stm32wl-hal/defmt-debug"]
-defmt-info = ["stm32wl-hal/defmt-info"]
-defmt-warn = ["stm32wl-hal/defmt-warn"]
-defmt-error = ["stm32wl-hal/defmt-error"]
+defmt-default = ["stm32wlxx-hal/defmt-default"]
+defmt-trace = ["stm32wlxx-hal/defmt-trace"]
+defmt-debug = ["stm32wlxx-hal/defmt-debug"]
+defmt-info = ["stm32wlxx-hal/defmt-info"]
+defmt-warn = ["stm32wlxx-hal/defmt-warn"]
+defmt-error = ["stm32wlxx-hal/defmt-error"]
 
-[dependencies.stm32wl-hal]
+[dependencies.stm32wlxx-hal]
 path = "../hal"
 features = ["stm32wle5"]

--- a/lora-e5-bsp/src/led.rs
+++ b/lora-e5-bsp/src/led.rs
@@ -1,6 +1,6 @@
 //! LEDs
 
-use stm32wl_hal as hal;
+use stm32wlxx_hal as hal;
 
 use core::ops::Not;
 use hal::{

--- a/lora-e5-bsp/src/lib.rs
+++ b/lora-e5-bsp/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod led;
 pub mod pb;
 
-pub use stm32wl_hal as hal;
+pub use stm32wlxx_hal as hal;
 
 use hal::{
     cortex_m::interrupt::CriticalSection,

--- a/lora-e5-bsp/src/pb.rs
+++ b/lora-e5-bsp/src/pb.rs
@@ -1,5 +1,5 @@
 //! Push-buttons
-use stm32wl_hal::{
+use stm32wlxx_hal::{
     cortex_m::interrupt::CriticalSection,
     gpio::{pins, Exti, Input, PinState, Pull},
 };

--- a/nucleo-wl55jc-bsp/Cargo.toml
+++ b/nucleo-wl55jc-bsp/Cargo.toml
@@ -9,21 +9,21 @@ edition = "2021"
 license = "MIT"
 keywords = ["arm", "cortex-m", "stm32", "bsp", "nucleo"]
 categories = ["embedded", "hardware-support", "no-std"]
-repository = "https://github.com/newAM/stm32wl-hal"
+repository = "https://github.com/newAM/stm32wlxx-hal"
 
 [features]
-defmt = ["stm32wl-hal/defmt"]
-rt = ["stm32wl-hal/rt"]
-stm32wl5x_cm4 = ["stm32wl-hal/stm32wl5x_cm4"]
-stm32wl5x_cm0p = ["stm32wl-hal/stm32wl5x_cm0p"]
+defmt = ["stm32wlxx-hal/defmt"]
+rt = ["stm32wlxx-hal/rt"]
+stm32wl5x_cm4 = ["stm32wlxx-hal/stm32wl5x_cm4"]
+stm32wl5x_cm0p = ["stm32wlxx-hal/stm32wl5x_cm0p"]
 
 # do NOT modify these features
-defmt-default = ["stm32wl-hal/defmt-default"]
-defmt-trace = ["stm32wl-hal/defmt-trace"]
-defmt-debug = ["stm32wl-hal/defmt-debug"]
-defmt-info = ["stm32wl-hal/defmt-info"]
-defmt-warn = ["stm32wl-hal/defmt-warn"]
-defmt-error = ["stm32wl-hal/defmt-error"]
+defmt-default = ["stm32wlxx-hal/defmt-default"]
+defmt-trace = ["stm32wlxx-hal/defmt-trace"]
+defmt-debug = ["stm32wlxx-hal/defmt-debug"]
+defmt-info = ["stm32wlxx-hal/defmt-info"]
+defmt-warn = ["stm32wlxx-hal/defmt-warn"]
+defmt-error = ["stm32wlxx-hal/defmt-error"]
 
-[dependencies.stm32wl-hal]
+[dependencies.stm32wlxx-hal]
 path = "../hal"

--- a/nucleo-wl55jc-bsp/src/led.rs
+++ b/nucleo-wl55jc-bsp/src/led.rs
@@ -1,6 +1,6 @@
 //! LEDs
 
-use stm32wl_hal as hal;
+use stm32wlxx_hal as hal;
 
 use hal::{
     cortex_m::interrupt::CriticalSection,

--- a/nucleo-wl55jc-bsp/src/lib.rs
+++ b/nucleo-wl55jc-bsp/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod led;
 pub mod pb;
 
-pub use stm32wl_hal as hal;
+pub use stm32wlxx_hal as hal;
 
 use hal::{
     cortex_m::interrupt::CriticalSection,

--- a/nucleo-wl55jc-bsp/src/pb.rs
+++ b/nucleo-wl55jc-bsp/src/pb.rs
@@ -1,5 +1,5 @@
 //! Push-buttons
-use stm32wl_hal::{
+use stm32wlxx_hal::{
     cortex_m::interrupt::CriticalSection,
     gpio::{pins, Exti, Input, PinState, Pull},
 };

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -76,4 +76,4 @@ $ cargo test -p testsuite --target thumbv7em-none-eabi --bin subghz -- --probe 0
 [newAM/probe-run]: https://github.com/newAM/probe-run
 [probe-run]: https://github.com/knurling-rs/probe-run
 [rustup]: https://rustup.rs/
-[#74]: https://github.com/newAM/stm32wl-hal/issues/74
+[#74]: https://github.com/newAM/stm32wlxx-hal/issues/74


### PR DESCRIPTION
This aligns this crate with those in the stm32-rs organization.